### PR TITLE
Refactor PacketType for Events

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
         "timestep_length_ms": 30
     },
     "network": {
-        "server_ip": "100.80.241.158",
+        "server_ip": "localhost",
         "server_port": 2355
     },
     "server": {

--- a/include/shared/network/packet.hpp
+++ b/include/shared/network/packet.hpp
@@ -34,8 +34,7 @@ enum class PacketType: uint16_t {
     ServerAssignEID,     ///< Sent by the server after TCP handshake, giving client its EID
 
     // Gameplay
-    ClientRequestEvent = 2000, ///< Client requesting server to perform specific input
-    ServerDoEvent,             ///< Server telling clients what events have occurred.
+    Event = 2000, ///< Client requesting server to perform specific input
 };
 
 /**
@@ -129,22 +128,13 @@ struct ServerAssignEIDPacket {
     }
 };
 
-struct ClientRequestEventPacket {
+struct EventPacket {
     Event event;
     
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
         ar & event;
     }
 };
-
-struct ServerDoEventPacket {
-    Event event;
-
-    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar & event;
-    }
-};
-
 
 /**
  * A class which wraps around a packet that has yet to be sent across the network.

--- a/include/shared/network/session.hpp
+++ b/include/shared/network/session.hpp
@@ -84,11 +84,9 @@ public:
      * Sends an event on the socket after packaging it into
      * the packet format.
      * 
-     * @param type Type of the event, should either be ServerDoEvent or
-     * ClientRequestEvent
      * @param evt The event object to send
      */
-    void sendEventAsync(PacketType type, Event evt);
+    void sendEventAsync(Event evt);
 
     /**
      * Get the information associated with this session.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -132,7 +132,7 @@ void Client::processClientInput() {
 
     if (movement.has_value()) {
         auto eid = 0; 
-        this->session->sendEventAsync(PacketType::ClientRequestEvent, Event(eid, EventType::MoveRelative, MoveRelativeEvent(eid, movement.value())));
+        this->session->sendEventAsync(Event(eid, EventType::MoveRelative, MoveRelativeEvent(eid, movement.value())));
     }
 }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -66,14 +66,14 @@ std::chrono::milliseconds Server::doTick() {
 
             // Tell each client the current lobby status
             for (const auto& [eid, session]: this->sessions) {
-                session->sendEventAsync(PacketType::ServerDoEvent, Event(this->world_eid,
+                session->sendEventAsync(Event(this->world_eid,
                     EventType::LoadGameState, LoadGameStateEvent(this->state)));
             };
 
             break;
         case GamePhase::GAME:
             for(const auto& [eid, session]: this->sessions) {
-                session->sendEventAsync(PacketType::ServerDoEvent, Event(this->world_eid, EventType::LoadGameState, LoadGameStateEvent(this->state)));
+                session->sendEventAsync(Event(this->world_eid, EventType::LoadGameState, LoadGameStateEvent(this->state)));
                 std::vector<Event> events = session->getEvents();
                 for(const Event& event: events) {
                     switch (event.type) {

--- a/src/shared/tests/serialize_test.cpp
+++ b/src/shared/tests/serialize_test.cpp
@@ -23,8 +23,8 @@ TEST(SerializeTest, SerializePacketEvent) {
     state.addPlayerToLobby(1, "Player Name");
     Event evt(0, EventType::LoadGameState, LoadGameStateEvent(state));
 
-    ServerDoEventPacket packet {.event=evt};
-    ServerDoEventPacket packet2 = deserialize<ServerDoEventPacket>(serialize(packet));
+    EventPacket packet {.event=evt};
+    EventPacket packet2 = deserialize<EventPacket>(serialize(packet));
 
     ASSERT_EQ(packet.event.type, EventType::LoadGameState);
     ASSERT_EQ(packet.event.type, packet2.event.type);


### PR DESCRIPTION
This PR combines ServerDoEvent and ClientRequestEvent PacketTypes into one PacketType::Event, because it is clear from the direction of communication what kind of event it is, and it helps remove boilerplate code.

Closes #32 