### PR TITLE
Player Movement Implementation with StartAction/StopAction Events

### DIFF
--- a/include/client/client.hpp
+++ b/include/client/client.hpp
@@ -61,6 +61,7 @@ private:
     static bool is_held_down;
     static bool is_held_right;
     static bool is_held_left;
+    static bool is_held_space;
 
     GameConfig config;
     tcp::resolver resolver;

--- a/include/client/client.hpp
+++ b/include/client/client.hpp
@@ -28,6 +28,7 @@ public:
     // Callbacks
     void displayCallback();
     void idleCallback(boost::asio::io_context& context);
+    void handleKeys(int eid, int keyType, bool keyHeld, bool *eventSent, glm::vec3 movement = glm::vec3(0.0f));
 
     // Bound window callbacks
     static void keyCallback(GLFWwindow *window, int key, int scancode, int action, int mods);
@@ -62,6 +63,7 @@ private:
     static bool is_held_right;
     static bool is_held_left;
     static bool is_held_space;
+    static bool is_held_shift;
 
     GameConfig config;
     tcp::resolver resolver;

--- a/include/client/cube.hpp
+++ b/include/client/cube.hpp
@@ -13,9 +13,9 @@
 
 class Cube {
 public:
-    Cube();
+    Cube(glm::vec3 newColor, glm::vec3 scale = glm::vec3(1.0f));
     ~Cube();
-    void draw(GLuint shader);
+    void draw(GLuint shader, bool fill);
     void update(glm::vec3 new_pos);
     void update_delta(glm::vec3 delta);
 
@@ -23,7 +23,7 @@ private:
     GLuint VAO;
     GLuint VBO_positions, VBO_normals, EBO;
 
-    glm::mat4 model;
+    glm::mat4 model;    
     glm::vec3 color;
 
 

--- a/include/client/cube.hpp
+++ b/include/client/cube.hpp
@@ -16,8 +16,7 @@ public:
     Cube(glm::vec3 newColor, glm::vec3 scale);
     ~Cube();
 
-    //void draw(GLuint shader, bool fill);
-    void draw(glm::mat4 viewProjMat, GLuint shader);
+    void draw(glm::mat4 viewProjMat, GLuint shader, bool fill);
     void update(glm::vec3 new_pos);
     void update_delta(glm::vec3 delta);
 

--- a/include/client/cube.hpp
+++ b/include/client/cube.hpp
@@ -13,7 +13,7 @@
 
 class Cube {
 public:
-    Cube(glm::vec3 newColor, glm::vec3 scale = glm::vec3(1.0f));
+    Cube(glm::vec3 newColor, glm::vec3 scale);
     ~Cube();
     void draw(GLuint shader, bool fill);
     void update(glm::vec3 new_pos);

--- a/include/server/game/constants.hpp
+++ b/include/server/game/constants.hpp
@@ -23,3 +23,4 @@
 
 /*	Game	*/
 #define	GRAVITY					0.005f
+#define	PLAYER_SPEED 			0.05f

--- a/include/server/game/constants.hpp
+++ b/include/server/game/constants.hpp
@@ -25,5 +25,5 @@
 #define INITIAL_HEALTH 100
 
 /*	Game	*/
-#define	GRAVITY					0.005f
-#define	PLAYER_SPEED 			0.05f
+#define	GRAVITY					0.03f
+#define	PLAYER_SPEED 			0.5f

--- a/include/server/game/constants.hpp
+++ b/include/server/game/constants.hpp
@@ -20,3 +20,6 @@
 //	SmartVector capacities
 #define	MAX_NUM_OBJECTS			100
 #define MAX_NUM_BASE_OBJECTS	100
+
+/*	Game	*/
+#define	GRAVITY					0.005f

--- a/include/shared/game/event.hpp
+++ b/include/shared/game/event.hpp
@@ -28,11 +28,14 @@
 enum class EventType {
     LobbyAction,
     LoadGameState,
+    StartAction,
+    StopAction, 
     VerticalKeyDown,
     HorizontalKeyDown,
     VerticalKeyUp,
     HorizontalKeyUp,
     Jump,
+    Sprint,
     MoveAbsolute,
     SpawnEntity,
     Filler
@@ -80,82 +83,34 @@ struct LoadGameStateEvent {
 };
 
 /**
- * Event for an entity moving a relative distance
+ * Event for action to start for generic key pressed / Can be updated to action type enum later
  */
-struct VerticalKeyDownEvent {
-    VerticalKeyDownEvent() {}
-    VerticalKeyDownEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
+struct StartActionEvent {
+    StartActionEvent() {}
+    StartActionEvent(EntityID entity_to_act, glm::vec3 movement, int glfw_key) : entity_to_act(entity_to_act), movement(movement), glfw_key(glfw_key) { }
 
+    EntityID entity_to_act;
     glm::vec3 movement;
-    EntityID entity_to_move;
-    /// some velocity / movement information...
+    int glfw_key;
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar& entity_to_move& movement;
+        ar& entity_to_act& movement& glfw_key;
     }
 };
 
 /**
- * Event for an entity moving a relative distance
+ * Event for action to stop for generic key pressed
  */
-struct HorizontalKeyDownEvent {
-    HorizontalKeyDownEvent() {}
-    HorizontalKeyDownEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
+struct StopActionEvent {
+    StopActionEvent() {}
+    StopActionEvent(EntityID entity_to_act, glm::vec3 movement, int glfw_key) : entity_to_act(entity_to_act), movement(movement), glfw_key(glfw_key) { }
 
+    EntityID entity_to_act;
     glm::vec3 movement;
-    EntityID entity_to_move;
-    /// some velocity / movement information...
+    int glfw_key;
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar& entity_to_move& movement;
-    }
-};
-
-/**
- * Event when vertical movement (up/down) moving key is back up
- */
-struct VerticalKeyUpEvent {
-    VerticalKeyUpEvent() {}
-    VerticalKeyUpEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
-
-    glm::vec3 movement;
-    EntityID entity_to_move;
-    /// some velocity / movement information...
-
-    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar& entity_to_move& movement;
-    }
-};
-
-/**
- * Event when horizontal movement (left/right) key is back up
- */
-struct HorizontalKeyUpEvent {
-    HorizontalKeyUpEvent() {}
-    HorizontalKeyUpEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
-
-    glm::vec3 movement;
-    EntityID entity_to_move;
-    /// some velocity / movement information...
-
-    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar& entity_to_move& movement;
-    }
-};
-
-/**
- * Event when jump (space)
- */
-struct JumpEvent {
-    JumpEvent() {}
-    JumpEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
-
-    glm::vec3 movement;
-    EntityID entity_to_move;
-    /// some velocity / movement information...
-
-    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar& entity_to_move& movement;
+        ar& entity_to_act& movement& glfw_key;
     }
 };
 
@@ -202,11 +157,14 @@ struct SpawnEntityEvent {
 using EventData = boost::variant<
     LobbyActionEvent,
     LoadGameStateEvent,
+    StartActionEvent,
+    StopActionEvent,
     VerticalKeyDownEvent,
     HorizontalKeyDownEvent,
     VerticalKeyUpEvent,
     HorizontalKeyUpEvent,
     JumpEvent,
+    SprintEvent,
     MoveAbsoluteEvent,
     SpawnEntityEvent
 >;

--- a/include/shared/game/event.hpp
+++ b/include/shared/game/event.hpp
@@ -179,18 +179,6 @@ struct SpawnEntityEvent {
 };
 
 /**
- * Filler Event (For client movement / dummy event)
- */
-struct FillerEvent {
-    FillerEvent() {}
-
-    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        // TODO:
-    }
-
-};
-
-/**
  * All of the different kinds of events in a tagged union, so we can
  * easily pull out the actual data for a specific Event
  */
@@ -202,8 +190,7 @@ using EventData = boost::variant<
     VerticalKeyUpEvent,
     HorizontalKeyUpEvent,
     MoveAbsoluteEvent,
-    SpawnEntityEvent,
-    FillerEvent
+    SpawnEntityEvent
 >;
 
 /**

--- a/include/shared/game/event.hpp
+++ b/include/shared/game/event.hpp
@@ -31,6 +31,7 @@ enum class EventType {
     LoadGameState,
     StartAction,
     StopAction, 
+    MoveRelative,
     MoveAbsolute,
     SpawnEntity,
 };
@@ -132,6 +133,22 @@ struct StopActionEvent {
 };
 
 /**
+ * Event for an entity moving a relative distance
+ */
+struct MoveRelativeEvent {
+    MoveRelativeEvent() {}
+    MoveRelativeEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
+
+    glm::vec3 movement;
+    EntityID entity_to_move;
+    /// some velocity / movement information...
+
+    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
+        ar & entity_to_move & movement;
+    }
+};
+
+/**
  * Event for an entity moving to some new absolute location
  */
 struct MoveAbsoluteEvent {
@@ -177,6 +194,7 @@ using EventData = boost::variant<
     LoadGameStateEvent,
     StartActionEvent,
     StopActionEvent,
+    MoveRelativeEvent,
     MoveAbsoluteEvent,
     SpawnEntityEvent
 >;

--- a/include/shared/game/event.hpp
+++ b/include/shared/game/event.hpp
@@ -29,8 +29,10 @@ enum class EventType {
     LobbyAction,
     LoadGameState,
     MoveRelative,
+    MoveKeyUp,
     MoveAbsolute,
     SpawnEntity,
+    Filler
 };
 
 /**
@@ -91,6 +93,20 @@ struct MoveRelativeEvent {
 };
 
 /**
+ * Event when moving key is back up
+ */
+struct MoveKeyUpEvent {
+    MoveKeyUpEvent() {}
+    MoveKeyUpEvent(EntityID entity_to_move) : entity_to_move(entity_to_move) { }
+
+    EntityID entity_to_move;
+
+    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
+        ar& entity_to_move;
+    }
+};
+
+/**
  * Event for an entity moving to some new absolute location
  */
 struct MoveAbsoluteEvent {
@@ -127,6 +143,18 @@ struct SpawnEntityEvent {
 };
 
 /**
+ * Filler Event (For client movement / dummy event)
+ */
+struct FillerEvent {
+    FillerEvent() {}
+
+    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
+        // TODO:
+    }
+
+};
+
+/**
  * All of the different kinds of events in a tagged union, so we can
  * easily pull out the actual data for a specific Event
  */
@@ -134,8 +162,10 @@ using EventData = boost::variant<
     LobbyActionEvent,
     LoadGameStateEvent,
     MoveRelativeEvent,
+    MoveKeyUpEvent,
     MoveAbsoluteEvent,
-    SpawnEntityEvent
+    SpawnEntityEvent,
+    FillerEvent
 >;
 
 /**

--- a/include/shared/game/event.hpp
+++ b/include/shared/game/event.hpp
@@ -30,15 +30,8 @@ enum class EventType {
     LoadGameState,
     StartAction,
     StopAction, 
-    VerticalKeyDown,
-    HorizontalKeyDown,
-    VerticalKeyUp,
-    HorizontalKeyUp,
-    Jump,
-    Sprint,
     MoveAbsolute,
     SpawnEntity,
-    Filler
 };
 
 /**
@@ -159,12 +152,6 @@ using EventData = boost::variant<
     LoadGameStateEvent,
     StartActionEvent,
     StopActionEvent,
-    VerticalKeyDownEvent,
-    HorizontalKeyDownEvent,
-    VerticalKeyUpEvent,
-    HorizontalKeyUpEvent,
-    JumpEvent,
-    SprintEvent,
     MoveAbsoluteEvent,
     SpawnEntityEvent
 >;

--- a/include/shared/game/event.hpp
+++ b/include/shared/game/event.hpp
@@ -37,8 +37,7 @@ enum class EventType {
 };
 
 enum class ActionType {
-    MoveHorizontal,
-    MoveVertical,
+    MoveCam,
     Jump,
     Sprint,
 };

--- a/include/shared/game/event.hpp
+++ b/include/shared/game/event.hpp
@@ -28,8 +28,10 @@
 enum class EventType {
     LobbyAction,
     LoadGameState,
-    MoveRelative,
-    MoveKeyUp,
+    VerticalKeyDown,
+    HorizontalKeyDown,
+    VerticalKeyUp,
+    HorizontalKeyUp,
     MoveAbsolute,
     SpawnEntity,
     Filler
@@ -79,9 +81,9 @@ struct LoadGameStateEvent {
 /**
  * Event for an entity moving a relative distance
  */
-struct MoveRelativeEvent {
-    MoveRelativeEvent() {}
-    MoveRelativeEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
+struct VerticalKeyDownEvent {
+    VerticalKeyDownEvent() {}
+    VerticalKeyDownEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
 
     glm::vec3 movement;
     EntityID entity_to_move;
@@ -93,16 +95,50 @@ struct MoveRelativeEvent {
 };
 
 /**
- * Event when moving key is back up
+ * Event for an entity moving a relative distance
  */
-struct MoveKeyUpEvent {
-    MoveKeyUpEvent() {}
-    MoveKeyUpEvent(EntityID entity_to_move) : entity_to_move(entity_to_move) { }
+struct HorizontalKeyDownEvent {
+    HorizontalKeyDownEvent() {}
+    HorizontalKeyDownEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
 
+    glm::vec3 movement;
     EntityID entity_to_move;
+    /// some velocity / movement information...
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar& entity_to_move;
+        ar & entity_to_move & movement;
+    }
+};
+
+/**
+ * Event when vertical movement (up/down) moving key is back up
+ */
+struct VerticalKeyUpEvent {
+    VerticalKeyUpEvent() {}
+    VerticalKeyUpEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
+
+    glm::vec3 movement;
+    EntityID entity_to_move;
+    /// some velocity / movement information...
+
+    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
+        ar & entity_to_move & movement;
+    }
+};
+
+/**
+ * Event when horizontal movement (left/right) key is back up
+ */
+struct HorizontalKeyUpEvent {
+    HorizontalKeyUpEvent() {}
+    HorizontalKeyUpEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
+
+    glm::vec3 movement;
+    EntityID entity_to_move;
+    /// some velocity / movement information...
+
+    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
+        ar & entity_to_move & movement;
     }
 };
 
@@ -161,8 +197,10 @@ struct FillerEvent {
 using EventData = boost::variant<
     LobbyActionEvent,
     LoadGameStateEvent,
-    MoveRelativeEvent,
-    MoveKeyUpEvent,
+    VerticalKeyDownEvent,
+    HorizontalKeyDownEvent,
+    VerticalKeyUpEvent,
+    HorizontalKeyUpEvent,
     MoveAbsoluteEvent,
     SpawnEntityEvent,
     FillerEvent

--- a/include/shared/game/event.hpp
+++ b/include/shared/game/event.hpp
@@ -34,6 +34,13 @@ enum class EventType {
     SpawnEntity,
 };
 
+enum class ActionType {
+    MoveHorizontal,
+    MoveVertical,
+    Jump,
+    Sprint,
+};
+
 /**
  * Override << so we can std::cout << EventType_var;
  */
@@ -80,14 +87,14 @@ struct LoadGameStateEvent {
  */
 struct StartActionEvent {
     StartActionEvent() {}
-    StartActionEvent(EntityID entity_to_act, glm::vec3 movement, int glfw_key) : entity_to_act(entity_to_act), movement(movement), glfw_key(glfw_key) { }
+    StartActionEvent(EntityID entity_to_act, glm::vec3 movement, ActionType action) : entity_to_act(entity_to_act), movement(movement), action(action) { }
 
     EntityID entity_to_act;
     glm::vec3 movement;
-    int glfw_key;
+    ActionType action;
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar& entity_to_act& movement& glfw_key;
+        ar& entity_to_act& movement& action;
     }
 };
 
@@ -96,14 +103,14 @@ struct StartActionEvent {
  */
 struct StopActionEvent {
     StopActionEvent() {}
-    StopActionEvent(EntityID entity_to_act, glm::vec3 movement, int glfw_key) : entity_to_act(entity_to_act), movement(movement), glfw_key(glfw_key) { }
+    StopActionEvent(EntityID entity_to_act, glm::vec3 movement, ActionType action) : entity_to_act(entity_to_act), movement(movement), action(action) { }
 
     EntityID entity_to_act;
     glm::vec3 movement;
-    int glfw_key;
+    ActionType action;
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar& entity_to_act& movement& glfw_key;
+        ar& entity_to_act& movement& action;
     }
 };
 

--- a/include/shared/game/event.hpp
+++ b/include/shared/game/event.hpp
@@ -10,21 +10,21 @@
 
 
 /****************************************************
- * 
+ *
  * Important notes for adding new events:
- * 
+ *
  * 1. Make sure you correctly define the serialization function for all data members
  * 2. Make sure you define two constructors: one "dummy" default constructor which
  *    does nothing, and one constructor to actually make the Events. The dummy constructor
  *    is needed to make everything compile.
  * 3. Make sure you add the new struct you make to the EventData boost::variant typedef
  *    further down.
- * 
+ *
  ***************************************************/
 
-/**
- * Tag for the different kind of events there are
- */
+ /**
+  * Tag for the different kind of events there are
+  */
 enum class EventType {
     LobbyAction,
     LoadGameState,
@@ -32,6 +32,7 @@ enum class EventType {
     HorizontalKeyDown,
     VerticalKeyUp,
     HorizontalKeyUp,
+    Jump,
     MoveAbsolute,
     SpawnEntity,
     Filler
@@ -58,7 +59,7 @@ struct LobbyActionEvent {
     Action action;
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar & action;
+        ar& action;
     }
 };
 
@@ -68,13 +69,13 @@ struct LobbyActionEvent {
  */
 struct LoadGameStateEvent {
     // Dummy value doesn't matter because will be overridden with whatever you deserialize
-    LoadGameStateEvent() : state(SharedGameState(GamePhase::TITLE_SCREEN, GameConfig{})){}
+    LoadGameStateEvent() : state(SharedGameState(GamePhase::TITLE_SCREEN, GameConfig{})) {}
     explicit LoadGameStateEvent(const SharedGameState& state) : state(state) {}
 
     SharedGameState state;
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar & state;
+        ar& state;
     }
 };
 
@@ -90,7 +91,7 @@ struct VerticalKeyDownEvent {
     /// some velocity / movement information...
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar & entity_to_move & movement;
+        ar& entity_to_move& movement;
     }
 };
 
@@ -106,7 +107,7 @@ struct HorizontalKeyDownEvent {
     /// some velocity / movement information...
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar & entity_to_move & movement;
+        ar& entity_to_move& movement;
     }
 };
 
@@ -122,7 +123,7 @@ struct VerticalKeyUpEvent {
     /// some velocity / movement information...
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar & entity_to_move & movement;
+        ar& entity_to_move& movement;
     }
 };
 
@@ -138,7 +139,23 @@ struct HorizontalKeyUpEvent {
     /// some velocity / movement information...
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar & entity_to_move & movement;
+        ar& entity_to_move& movement;
+    }
+};
+
+/**
+ * Event when jump (space)
+ */
+struct JumpEvent {
+    JumpEvent() {}
+    JumpEvent(EntityID entity_to_move, glm::vec3 movement) : entity_to_move(entity_to_move), movement(movement) { }
+
+    glm::vec3 movement;
+    EntityID entity_to_move;
+    /// some velocity / movement information...
+
+    DEF_SERIALIZE(Archive& ar, const unsigned int version) {
+        ar& entity_to_move& movement;
     }
 };
 
@@ -189,12 +206,13 @@ using EventData = boost::variant<
     HorizontalKeyDownEvent,
     VerticalKeyUpEvent,
     HorizontalKeyUpEvent,
+    JumpEvent,
     MoveAbsoluteEvent,
     SpawnEntityEvent
 >;
 
 /**
- * Struct to represent any possible event that could happen in our game. 
+ * Struct to represent any possible event that could happen in our game.
  */
 struct Event {
     Event() {}
@@ -212,13 +230,13 @@ struct Event {
     EventData data;
 
     DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-        ar & evt_source & type & data;
+        ar& evt_source& type& data;
     }
 };
 
 /**
  * Allow us to std::cout an Event
- * 
+ *
  * TODO: actually output the data for the EventData
  */
 std::ostream& operator<<(std::ostream& os, const Event& evt);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -121,6 +121,7 @@ void Client::idleCallback(boost::asio::io_context& context) {
 
     if (is_held_right || is_held_left || is_held_up || is_held_down) {
         if (prevEvent.type == EventType::MoveRelative) {
+            processServerInput(context);
             return;
         }
         auto eid = 0; 
@@ -129,6 +130,7 @@ void Client::idleCallback(boost::asio::io_context& context) {
     }
     else {
         if (prevEvent.type == EventType::MoveKeyUp) {
+            processServerInput(context);
             return;
         }
         auto eid = 0;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -158,6 +158,12 @@ void Client::idleCallback(boost::asio::io_context& context) {
         sentHorizontalMovement = horizontal.value();
     }
 
+    if (sentVerticalMovement != vertical.value()){
+        auto eid = 0;
+        this->session->sendEventAsync(Event(eid, EventType::StartAction, StartActionEvent(eid, vertical.value(), ActionType::MoveVertical)));
+        sentVerticalMovement = vertical.value();
+    }
+
     std::optional<glm::vec3> cam_movement = glm::vec3(0.0f);
     if(cam_is_held_right)
         cam_movement.value() += cam->move(false, 1.0f);
@@ -170,11 +176,6 @@ void Client::idleCallback(boost::asio::io_context& context) {
 
 
     cam->update(mouse_xpos, mouse_ypos);
-
-    if (movement.has_value()) {
-        auto eid = 0; 
-        this->session->sendEventAsync(Event(eid, EventType::MoveRelative, MoveRelativeEvent(eid, movement.value())));
-    }
 
     // Send 'player' movement
     if (cam_movement.has_value() && this->session->getInfo().client_eid.has_value()) {
@@ -242,10 +243,10 @@ void Client::draw() {
         }
 
         //  tmp: all objects are cubes
-        Cube* cube = new Cube();
+        Cube* cube = new Cube(glm::vec3(0.0f,1.0f,1.0f), glm::vec3(1.0f));
         cube->update(sharedObject->physics.position);
         
-        cube->draw(this->cam->getViewProj(), this->cubeShaderProgram);
+        cube->draw(this->cam->getViewProj(), this->cubeShaderProgram, false);
     }
 }
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -26,7 +26,6 @@ bool Client::is_held_shift = false;
 // Checker for events sent / later can be made in an array
 glm::vec3 sentCamMovement = glm::vec3(-1.0f);
 
-bool spaceEvent = false;
 bool shiftEvent = false;
 
 bool Client::cam_is_held_up = false;
@@ -151,7 +150,6 @@ void Client::idleCallback(boost::asio::io_context& context) {
         // Send jump action
         if (is_held_space) {
             this->session->sendEventAsync(Event(eid, EventType::StartAction, StartActionEvent(eid, jump.value(), ActionType::Jump)));
-            spaceEvent = true;
         }
 
         // Handles individual keys
@@ -188,7 +186,7 @@ void Client::handleKeys(int eid, int keyType, bool keyHeld, bool *eventSent, glm
         this->session->sendEventAsync(Event(eid, EventType::StartAction, StartActionEvent(eid, movement, sendAction)));
         *eventSent = true;
     }
-    if (!keyHeld && eventSent) {
+    if (!keyHeld && *eventSent) {
         this->session->sendEventAsync(Event(eid, EventType::StopAction, StopActionEvent(eid, movement, sendAction)));
         *eventSent = false;
     }

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -202,7 +202,7 @@ void Client::draw() {
         std::cout << "got an object" << std::endl;
         //  tmp: all objects are cubes
         if(i == 0){
-            Cube* cube = new Cube(glm::vec3( 0.0f, 1.0f, 1.0f ));
+            Cube* cube = new Cube(glm::vec3( 0.0f, 1.0f, 1.0f ), glm::vec3( 1.0f ));
             cube->update(sharedObject->physics.position);
             cube->draw(this->cubeShaderProgram, true);
         } else {

--- a/src/client/cube.cpp
+++ b/src/client/cube.cpp
@@ -8,6 +8,8 @@ Cube::Cube(glm::vec3 newColor, glm::vec3 scale) {
     glm::vec3 cubeMin = glm::vec3(-1.0f, -1.0f, -1.0f);
     glm::vec3 cubeMax = glm::vec3(1.0f, 1.0f, 1.0f);
     model = glm::mat4(1.0f);
+
+    //scale the cube to with given vector
     model = glm::scale(model, scale);
 
     // The color of the cube. Try setting it to something else!

--- a/src/client/cube.cpp
+++ b/src/client/cube.cpp
@@ -137,8 +137,7 @@ Cube::~Cube() {
     glDeleteVertexArrays(1, &VAO);
 }
 
-//void Cube::draw(GLuint shader, bool fill) {
-void Cube::draw(glm::mat4 viewProjMat, GLuint shader) {
+void Cube::draw(glm::mat4 viewProjMat, GLuint shader, bool fill) {
     // actiavte the shader program
     glUseProgram(shader);
 

--- a/src/client/cube.cpp
+++ b/src/client/cube.cpp
@@ -1,6 +1,6 @@
 #include "client/cube.hpp"
 
-Cube::Cube() {
+Cube::Cube(glm::vec3 newColor, glm::vec3 scale) {
     // create a vertex buffer for positions and normals
     // insert the data into these buffers
     // initialize model matrix
@@ -8,9 +8,10 @@ Cube::Cube() {
     glm::vec3 cubeMin = glm::vec3(-1.0f, -1.0f, -1.0f);
     glm::vec3 cubeMax = glm::vec3(1.0f, 1.0f, 1.0f);
     model = glm::mat4(1.0f);
+    model = glm::scale(model, scale);
 
     // The color of the cube. Try setting it to something else!
-    color = glm::vec3(0.0f, 1.0f, 1.0f);
+    color = newColor;
 
     // Specify vertex positions
     positions = {
@@ -136,7 +137,7 @@ Cube::~Cube() {
     glDeleteVertexArrays(1, &VAO);
 }
 
-void Cube::draw(GLuint shader) {
+void Cube::draw(GLuint shader, bool fill) {
     // actiavte the shader program
     // std::cout << "draw" << std::endl;
 
@@ -174,8 +175,11 @@ void Cube::draw(GLuint shader) {
     glBindVertexArray(VAO);
 
     // Drawing mode for cube (wireframe vs filled)
-    glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-    // glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    if(fill){
+        glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    } else {
+        glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    }
 
     // draw the points using triangles, indexed with the EBO
     glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -26,16 +26,16 @@ target_link_libraries(${LIB_NAME}
     Boost::serialization
     nlohmann_json::nlohmann_json
 )
-target_include_directories(${LIB_NAME} PRIVATE ${GLM_LIBRARY_INCLUDES})
-target_link_libraries(${LIB_NAME} PRIVATE glm::glm)
+target_include_directories(${LIB_NAME} PRIVATE ${OPENGL_INCLUDE_DIRS} glfw glm ${imgui-directory} "${CMAKE_BINARY_DIR}/_deps/glew-src/include")
+target_link_libraries(${LIB_NAME} PRIVATE glm glfw libglew_static)
 
 add_executable(${TARGET_NAME} main.cpp)
 
 target_include_directories(${TARGET_NAME} PRIVATE ${INCLUDE_DIRECTORY})
 target_link_libraries(${TARGET_NAME} PRIVATE game_shared_lib ${LIB_NAME})
 
-target_include_directories(${TARGET_NAME} PRIVATE ${GLM_LIBRARY_INCLUDES})
-target_link_libraries(${TARGET_NAME} PRIVATE glm::glm)
+target_include_directories(${TARGET_NAME} PRIVATE ${OPENGL_INCLUDE_DIRS} glfw glm ${imgui-directory} "${CMAKE_BINARY_DIR}/_deps/glew-src/include")
+target_link_libraries(${TARGET_NAME} PRIVATE glm glfw libglew_static)
 
 target_include_directories(${TARGET_NAME} PRIVATE ${BOOST_LIBRARY_INCLUDES})
 target_link_libraries(${TARGET_NAME} 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -26,16 +26,16 @@ target_link_libraries(${LIB_NAME}
     Boost::serialization
     nlohmann_json::nlohmann_json
 )
-target_include_directories(${LIB_NAME} PRIVATE ${OPENGL_INCLUDE_DIRS} glfw glm ${imgui-directory} "${CMAKE_BINARY_DIR}/_deps/glew-src/include")
-target_link_libraries(${LIB_NAME} PRIVATE glm glfw libglew_static)
+target_include_directories(${LIB_NAME} PRIVATE ${GLM_LIBRARY_INCLUDES})
+target_link_libraries(${LIB_NAME} PRIVATE glm::glm)
 
 add_executable(${TARGET_NAME} main.cpp)
 
 target_include_directories(${TARGET_NAME} PRIVATE ${INCLUDE_DIRECTORY})
 target_link_libraries(${TARGET_NAME} PRIVATE game_shared_lib ${LIB_NAME})
 
-target_include_directories(${TARGET_NAME} PRIVATE ${OPENGL_INCLUDE_DIRS} glfw glm ${imgui-directory} "${CMAKE_BINARY_DIR}/_deps/glew-src/include")
-target_link_libraries(${TARGET_NAME} PRIVATE glm glfw libglew_static)
+target_include_directories(${TARGET_NAME} PRIVATE ${GLM_LIBRARY_INCLUDES})
+target_link_libraries(${TARGET_NAME} PRIVATE glm::glm)
 
 target_include_directories(${TARGET_NAME} PRIVATE ${BOOST_LIBRARY_INCLUDES})
 target_link_libraries(${TARGET_NAME} 

--- a/src/server/game/object.cpp
+++ b/src/server/game/object.cpp
@@ -16,7 +16,7 @@ Object::Object(ObjectType type) {
 	this->physics.shared.facing = glm::vec3(1.0f, 0.0f, 0.0f);
 
 	this->physics.velocity = glm::vec3(0.0f, 0.0f, 0.0f);
-	this->physics.acceleration = glm::vec3(0.0f, 0.0f, 0.0f);
+	this->physics.acceleration = glm::vec3(1.0f, 1.0f, 1.0f);
 	this->physics.movable = true;
 
 	//	By default, the object is not assigned a collider (must be explicitly

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -92,8 +92,7 @@ void ServerGameState::update(const EventList& events) {
 			}
 			break;
 		}
-		default: {}
-		//     std::cerr << "Unimplemented EventType (" << event.type << ") received" << std::endl;
+	
         case EventType::MoveRelative:
 		{
 			//currently just sets the velocity to given 

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -48,15 +48,25 @@ SharedGameState ServerGameState::generateSharedGameState() {
 void ServerGameState::update(const EventList& events) {
 
 	for (const auto& [src_eid, event] : events) { // cppcheck-suppress unusedVariable
+		std::cout << event << std::endl;
+		Object* obj;
         switch (event.type) {
-        case EventType::MoveRelative:
-			//currently just sets the velocity to given 
-            auto moveRelativeEvent = boost::get<MoveRelativeEvent>(event.data);
-            Object* obj = this->objects.getObject(moveRelativeEvent.entity_to_move);
-            obj->physics.velocity += moveRelativeEvent.movement;
-            break;
-            // default:
-            //     std::cerr << "Unimplemented EventType (" << event.type << ") received" << std::endl;
+
+		case EventType::MoveRelative: {	// if key down, set the velocity to given 
+			auto moveRelativeEvent = boost::get<MoveRelativeEvent>(event.data);
+			obj = this->objects.getObject(moveRelativeEvent.entity_to_move);
+			obj->physics.velocity = moveRelativeEvent.movement;
+			break;
+		}
+		case EventType::MoveKeyUp: { // if key is off, stop moving	
+			auto stopMove = boost::get<MoveKeyUpEvent>(event.data);
+			obj = this->objects.getObject(stopMove.entity_to_move);
+			obj->physics.velocity = glm::vec3(0.0f, 0.0f, 0.0f);
+			break;
+		}
+
+		default: {}
+		//     std::cerr << "Unimplemented EventType (" << event.type << ") received" << std::endl;
         }
     }
 
@@ -85,7 +95,6 @@ void ServerGameState::updateMovement() {
 			//	object position [meters]
 			//	= old position [meters] + (velocity [meters / timestep] * 1 timestep)
 			object->physics.shared.position += object->physics.velocity;
-			object->physics.velocity -= object->physics.velocity;
 
 
 			//	Object velocity [meters / timestep]

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -50,18 +50,33 @@ void ServerGameState::update(const EventList& events) {
 	for (const auto& [src_eid, event] : events) { // cppcheck-suppress unusedVariable
 		std::cout << event << std::endl;
 		Object* obj;
+		float speedFactor = 0.05; // temperary speed factor for movement
         switch (event.type) {
 
-		case EventType::MoveRelative: {	// if key down, set the velocity to given 
-			auto moveRelativeEvent = boost::get<MoveRelativeEvent>(event.data);
-			obj = this->objects.getObject(moveRelativeEvent.entity_to_move);
-			obj->physics.velocity = moveRelativeEvent.movement;
+		case EventType::HorizontalKeyDown: {	// if left/right key down, set the velocity to given 
+			auto horizontalEvent = boost::get<HorizontalKeyDownEvent>(event.data);
+			obj = this->objects.getObject(horizontalEvent.entity_to_move);
+			obj->physics.velocity = obj->physics.velocity * glm::vec3(0.0f, 1.0f, 1.0f);
+			obj->physics.velocity += horizontalEvent.movement * speedFactor;
 			break;
 		}
-		case EventType::MoveKeyUp: { // if key is off, stop moving	
-			auto stopMove = boost::get<MoveKeyUpEvent>(event.data);
-			obj = this->objects.getObject(stopMove.entity_to_move);
-			obj->physics.velocity = glm::vec3(0.0f, 0.0f, 0.0f);
+		case EventType::VerticalKeyDown: {	// if up/down key down, set the velocity to given 
+			auto verticalEvent = boost::get<VerticalKeyDownEvent>(event.data);
+			obj = this->objects.getObject(verticalEvent.entity_to_move);
+			obj->physics.velocity = obj->physics.velocity * glm::vec3(1.0f, 0.0f, 1.0f);
+			obj->physics.velocity += verticalEvent.movement * speedFactor;
+			break;
+		}
+		case EventType::HorizontalKeyUp: { // if key is off, stop moving horizontally
+			auto stopHorizontalEvent = boost::get<HorizontalKeyUpEvent>(event.data);
+			obj = this->objects.getObject(stopHorizontalEvent.entity_to_move);
+			obj->physics.velocity = obj->physics.velocity * glm::vec3(0.0f, 1.0f, 1.0f);
+			break;
+		}
+		case EventType::VerticalKeyUp: { // if key is off, stop moving vertically
+			auto stopVerticalEvent = boost::get<VerticalKeyUpEvent>(event.data);
+			obj = this->objects.getObject(stopVerticalEvent.entity_to_move);
+			obj->physics.velocity = obj->physics.velocity * glm::vec3(1.0f, 0.0f, 1.0f);
 			break;
 		}
 

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -52,6 +52,14 @@ void ServerGameState::update(const EventList& events) {
 		Object* obj;
 	
         switch (event.type) {
+		case EventType::ChangeFacing:
+		{
+			//currently just sets the velocity to given 
+            auto changeFacingEvent = boost::get<ChangeFacingEvent>(event.data);
+            Object* objChangeFace = this->objects.getObject(changeFacingEvent.entity_to_change_face);
+            objChangeFace->physics.shared.facing = changeFacingEvent.facing;
+            break;
+		}
 	
 		case EventType::StartAction: {
 			auto startAction = boost::get<StartActionEvent>(event.data);
@@ -102,15 +110,6 @@ void ServerGameState::update(const EventList& events) {
             break;
 		}
 
-        case EventType::ChangeFacing:
-		{
-			//currently just sets the velocity to given 
-            auto changeFacingEvent = boost::get<ChangeFacingEvent>(event.data);
-            Object* objChangeFace = this->objects.getObject(changeFacingEvent.entity_to_change_face);
-            objChangeFace->physics.shared.facing = changeFacingEvent.facing;
-            break;
-		}
-
 		// default:
 		//     std::cerr << "Unimplemented EventType (" << event.type << ") received" << std::endl;
         }
@@ -140,7 +139,7 @@ void ServerGameState::updateMovement() {
 		if (object->physics.movable) {
 			//TODO : check for collision at position to move, if so, dont change position
 
-			object->physics.shared.position += object->physics.velocity * object->physics.acceleration;
+			object->physics.shared.position += object->physics.velocity * object->physics.acceleration * object->physics.shared.facing;
 
 			// update gravity factor
 			if ((object->physics.shared.position).y >= 0) {

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -50,28 +50,28 @@ void ServerGameState::update(const EventList& events) {
 	for (const auto& [src_eid, event] : events) { // cppcheck-suppress unusedVariable
 		std::cout << event << std::endl;
 		Object* obj;
-		float speedFactor = 0.05; // temporary speed factor for movement (later should be in creature)
+	
         switch (event.type) {
 
 		case EventType::Jump: {
 			auto jumpEvent = boost::get<JumpEvent>(event.data);
 			obj = this->objects.getObject(jumpEvent.entity_to_move);
 			if (obj->physics.velocity.y != 0) { break; }
-			obj->physics.velocity += jumpEvent.movement * speedFactor * 2.0f;
+			obj->physics.velocity += jumpEvent.movement * PLAYER_SPEED * 2.0f;
 			break;
 		}
 		case EventType::HorizontalKeyDown: {	// if left/right key down, set the velocity to given 
 			auto horizontalEvent = boost::get<HorizontalKeyDownEvent>(event.data);
 			obj = this->objects.getObject(horizontalEvent.entity_to_move);
 			obj->physics.velocity = obj->physics.velocity * glm::vec3(0.0f, 1.0f, 1.0f);
-			obj->physics.velocity += horizontalEvent.movement * speedFactor;
+			obj->physics.velocity += horizontalEvent.movement * PLAYER_SPEED;
 			break;
 		}
 		case EventType::VerticalKeyDown: {	// if up/down key down, set the velocity to given 
 			auto verticalEvent = boost::get<VerticalKeyDownEvent>(event.data);
 			obj = this->objects.getObject(verticalEvent.entity_to_move);
 			obj->physics.velocity = obj->physics.velocity * glm::vec3(1.0f, 1.0f, 0.0f);
-			obj->physics.velocity += verticalEvent.movement * speedFactor;
+			obj->physics.velocity += verticalEvent.movement * PLAYER_SPEED;
 			break;
 		}
 		case EventType::HorizontalKeyUp: { // if key is off, stop moving horizontally

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -50,7 +50,7 @@ void ServerGameState::update(const EventList& events) {
 	for (const auto& [src_eid, event] : events) { // cppcheck-suppress unusedVariable
 		std::cout << event << std::endl;
 		Object* obj;
-		float speedFactor = 0.05; // temperary speed factor for movement
+		float speedFactor = 0.05; // temporary speed factor for movement
         switch (event.type) {
 
 		case EventType::HorizontalKeyDown: {	// if left/right key down, set the velocity to given 
@@ -107,15 +107,9 @@ void ServerGameState::updateMovement() {
 			continue;
 		
 		if (object->physics.movable) {
-			//	object position [meters]
-			//	= old position [meters] + (velocity [meters / timestep] * 1 timestep)
+			//TODO : check for collision at position to move, if so, dont change position
+
 			object->physics.shared.position += object->physics.velocity;
-
-
-			//	Object velocity [meters / timestep]
-			//	=	old velocity [meters / timestep]
-			//		+ (acceleration [meters / timestep^2] * 1 timestep)
-			//object->physics.velocity += object->physics.acceleration;
 		}
 	}
 }

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -50,9 +50,16 @@ void ServerGameState::update(const EventList& events) {
 	for (const auto& [src_eid, event] : events) { // cppcheck-suppress unusedVariable
 		std::cout << event << std::endl;
 		Object* obj;
-		float speedFactor = 0.05; // temporary speed factor for movement
+		float speedFactor = 0.05; // temporary speed factor for movement (later should be in creature)
         switch (event.type) {
 
+		case EventType::Jump: {
+			auto jumpEvent = boost::get<JumpEvent>(event.data);
+			obj = this->objects.getObject(jumpEvent.entity_to_move);
+			if (obj->physics.velocity.y != 0) { break; }
+			obj->physics.velocity += jumpEvent.movement * speedFactor * 2.0f;
+			break;
+		}
 		case EventType::HorizontalKeyDown: {	// if left/right key down, set the velocity to given 
 			auto horizontalEvent = boost::get<HorizontalKeyDownEvent>(event.data);
 			obj = this->objects.getObject(horizontalEvent.entity_to_move);
@@ -63,7 +70,7 @@ void ServerGameState::update(const EventList& events) {
 		case EventType::VerticalKeyDown: {	// if up/down key down, set the velocity to given 
 			auto verticalEvent = boost::get<VerticalKeyDownEvent>(event.data);
 			obj = this->objects.getObject(verticalEvent.entity_to_move);
-			obj->physics.velocity = obj->physics.velocity * glm::vec3(1.0f, 0.0f, 1.0f);
+			obj->physics.velocity = obj->physics.velocity * glm::vec3(1.0f, 1.0f, 0.0f);
 			obj->physics.velocity += verticalEvent.movement * speedFactor;
 			break;
 		}
@@ -76,7 +83,7 @@ void ServerGameState::update(const EventList& events) {
 		case EventType::VerticalKeyUp: { // if key is off, stop moving vertically
 			auto stopVerticalEvent = boost::get<VerticalKeyUpEvent>(event.data);
 			obj = this->objects.getObject(stopVerticalEvent.entity_to_move);
-			obj->physics.velocity = obj->physics.velocity * glm::vec3(1.0f, 0.0f, 1.0f);
+			obj->physics.velocity = obj->physics.velocity * glm::vec3(1.0f, 1.0f, 0.0f);
 			break;
 		}
 
@@ -110,6 +117,13 @@ void ServerGameState::updateMovement() {
 			//TODO : check for collision at position to move, if so, dont change position
 
 			object->physics.shared.position += object->physics.velocity;
+
+			// update gravity factor
+			if ((object->physics.shared.position).y >= 0) {
+				object->physics.velocity.y -= GRAVITY;
+			} else {
+				object->physics.velocity.y = 0.0f;
+			}
 		}
 	}
 }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -34,6 +34,10 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
 {
     state.objects.createObject(ObjectType::Object);
     
+    EntityID floorID = state.objects.createObject(ObjectType::Object);
+    Object* floor = (Object*)state.objects.getObject(floorID);
+    floor->physics.shared.position = glm::vec3(0.0f, -1.3f, 0.0f);
+    
     _doAccept(); // start asynchronously accepting
 
     if (config.server.lobby_broadcast) {

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -35,7 +35,7 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
     state.objects.createObject(ObjectType::Object);
     
     EntityID floorID = state.objects.createObject(ObjectType::Object);
-    Object* floor = (Object*)state.objects.getObject(floorID);
+    Object* floor = state.objects.getObject(floorID);
     floor->physics.shared.position = glm::vec3(0.0f, -1.3f, 0.0f);
     
     _doAccept(); // start asynchronously accepting

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -43,7 +43,7 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
     EntityID floorID = state.objects.createObject(ObjectType::SolidSurface);
 
     //  Specify wall positions (RECREATED TO MATCH AXIS)
-    //  Configuration: 40 (z) x 32 (x) room example
+    //  Configuration: 18 (z) x 20 (x) room example
     // (z-axis)
     //  ##1##
     //  #   #

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -34,6 +34,7 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
 {
     state.objects.createObject(ObjectType::Object);
 
+    /*
     //  Create a room
     EntityID wall1ID = state.objects.createObject(ObjectType::SolidSurface);
     EntityID wall2ID = state.objects.createObject(ObjectType::SolidSurface);
@@ -78,7 +79,7 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
     //  floor has dimensions (40, 32, 1) and position (0, 0, -0.5)
     floor->shared.dimensions = glm::vec3(40, 32, 1);
     floor->physics.shared.position = glm::vec3(0, 0, -0.5);
-    floor->physics.movable = false;
+    floor->physics.movable = false;*/
 
     
     EntityID floorID = state.objects.createObject(ObjectType::Object);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -34,7 +34,7 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
 {
     state.objects.createObject(ObjectType::Object);
 
-    /*
+    
     //  Create a room
     EntityID wall1ID = state.objects.createObject(ObjectType::SolidSurface);
     EntityID wall2ID = state.objects.createObject(ObjectType::SolidSurface);
@@ -43,10 +43,11 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
     EntityID floorID = state.objects.createObject(ObjectType::SolidSurface);
 
     //  Specify wall positions
-    //  Configuration: 40 (x) x 32 (y) room example
+    //  Configuration: 40 (z) x 32 (x) room example
+    // (z-axis)
     //  ##1##
     //  #   #
-    //  2   3
+    //  2   3 (x-axis)
     //  #   #
     //  ##4##
 
@@ -57,34 +58,29 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
     SolidSurface* floor = (SolidSurface*)state.objects.getObject(floorID);
 
     //  Wall1 has dimensions (40, 1, 4) and position (0, 15.5, 2)
-    wall1->shared.dimensions = glm::vec3(40, 1, 4);
-    wall1->physics.shared.position = glm::vec3(0, 15.5, 2);
+    wall1->shared.dimensions = glm::vec3(20, 4, 1);
+    wall1->physics.shared.position = glm::vec3(0, 0, -19.5);
     wall1->physics.movable = false;
 
     //  Wall2 has dimensions (30, 1, 4) and position (-19.5, 0, 2)
-    wall2->shared.dimensions = glm::vec3(30, 1, 4);
-    wall2->physics.shared.position = glm::vec3(-19.5, 0, 2);
+    wall2->shared.dimensions = glm::vec3(1, 4, 18);
+    wall2->physics.shared.position = glm::vec3(-19.5, 0, 0);
     wall2->physics.movable = false;
 
     //  Wall3 has dimensions (30, 1, 4) and position (19.5, 0, 2)
-    wall3->shared.dimensions = glm::vec3(30, 1, 4);
-    wall3->physics.shared.position = glm::vec3(19.5, 0, 2);
+    wall3->shared.dimensions = glm::vec3(1, 4, 18);
+    wall3->physics.shared.position = glm::vec3(19.5, 0, 0);
     wall3->physics.movable = false;
 
     //  Wall4 has dimensions (40, 1, 4) and position (0, -15.5, 2)
-    wall4->shared.dimensions = glm::vec3(40, 1, 4);
-    wall4->physics.shared.position = glm::vec3(0, -15.5, 2);
+    wall4->shared.dimensions = glm::vec3(20, 4, 1);
+    wall4->physics.shared.position = glm::vec3(0, 0, 19.5);
     wall4->physics.movable = false;
 
     //  floor has dimensions (40, 32, 1) and position (0, 0, -0.5)
-    floor->shared.dimensions = glm::vec3(40, 32, 1);
-    floor->physics.shared.position = glm::vec3(0, 0, -0.5);
-    floor->physics.movable = false;*/
-
-    
-    EntityID floorID = state.objects.createObject(ObjectType::Object);
-    Object* floor = state.objects.getObject(floorID);
+    floor->shared.dimensions = glm::vec3(20.0f, 0.1f, 20.0f);
     floor->physics.shared.position = glm::vec3(0.0f, -1.3f, 0.0f);
+    floor->physics.movable = false;
     
     _doAccept(); // start asynchronously accepting
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -42,7 +42,7 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
     EntityID wall4ID = state.objects.createObject(ObjectType::SolidSurface);
     EntityID floorID = state.objects.createObject(ObjectType::SolidSurface);
 
-    //  Specify wall positions
+    //  Specify wall positions (RECREATED TO MATCH AXIS)
     //  Configuration: 40 (z) x 32 (x) room example
     // (z-axis)
     //  ##1##
@@ -57,27 +57,27 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
     SolidSurface* wall4 = (SolidSurface*)state.objects.getObject(wall4ID);
     SolidSurface* floor = (SolidSurface*)state.objects.getObject(floorID);
 
-    //  Wall1 has dimensions (40, 1, 4) and position (0, 15.5, 2)
+    //  Wall1 has dimensions (20, 4, 1); and position (0, 0, -19.5)
     wall1->shared.dimensions = glm::vec3(20, 4, 1);
     wall1->physics.shared.position = glm::vec3(0, 0, -19.5);
     wall1->physics.movable = false;
 
-    //  Wall2 has dimensions (30, 1, 4) and position (-19.5, 0, 2)
+    //  Wall2 has dimensions (1, 4, 18) and position (-19.5, 0, 0)
     wall2->shared.dimensions = glm::vec3(1, 4, 18);
     wall2->physics.shared.position = glm::vec3(-19.5, 0, 0);
     wall2->physics.movable = false;
 
-    //  Wall3 has dimensions (30, 1, 4) and position (19.5, 0, 2)
+    //  Wall3 has dimensions (1, 4, 18) and position (19.5, 0, 0)
     wall3->shared.dimensions = glm::vec3(1, 4, 18);
     wall3->physics.shared.position = glm::vec3(19.5, 0, 0);
     wall3->physics.movable = false;
 
-    //  Wall4 has dimensions (40, 1, 4) and position (0, -15.5, 2)
+    //  Wall4 has dimensions (20, 4, 1) and position (0, 0, 19.5)
     wall4->shared.dimensions = glm::vec3(20, 4, 1);
     wall4->physics.shared.position = glm::vec3(0, 0, 19.5);
     wall4->physics.movable = false;
 
-    //  floor has dimensions (40, 32, 1) and position (0, 0, -0.5)
+    //  floor has dimensions (20, 0.1, 20) and position (0, -1.3, 0)
     floor->shared.dimensions = glm::vec3(20.0f, 0.1f, 20.0f);
     floor->physics.shared.position = glm::vec3(0.0f, -1.3f, 0.0f);
     floor->physics.movable = false;

--- a/src/shared/game/event.cpp
+++ b/src/shared/game/event.cpp
@@ -17,6 +17,7 @@ std::ostream& operator<<(std::ostream& os, const EventType& type) {
         TO_STR(LoadGameState);
         TO_STR(StartAction);
         TO_STR(StopAction);
+        TO_STR(MoveRelative);
         TO_STR(MoveAbsolute);
         TO_STR(SpawnEntity);
     default:

--- a/src/shared/game/event.cpp
+++ b/src/shared/game/event.cpp
@@ -1,7 +1,7 @@
 #include "shared/game/event.hpp"
 
 std::ostream& operator<<(std::ostream& os, const Event& evt) {
-    os << "Event { .evt_source=" << evt.evt_source 
+    os << "Event { .evt_source=" << evt.evt_source
         << " .type=" << evt.type << "}";
     return os;
 }
@@ -19,11 +19,12 @@ std::ostream& operator<<(std::ostream& os, const EventType& type) {
         TO_STR(HorizontalKeyDown);
         TO_STR(VerticalKeyUp);
         TO_STR(HorizontalKeyUp);
+        TO_STR(Jump);
         TO_STR(MoveAbsolute);
         TO_STR(SpawnEntity);
-        default: 
-            os << "Unknown EventType";
-            break;
+    default:
+        os << "Unknown EventType";
+        break;
     }
     return os;
 }

--- a/src/shared/game/event.cpp
+++ b/src/shared/game/event.cpp
@@ -16,8 +16,10 @@ std::ostream& operator<<(std::ostream& os, const EventType& type) {
         TO_STR(LobbyAction);
         TO_STR(LoadGameState);
         TO_STR(MoveRelative);
+        TO_STR(MoveKeyUp);
         TO_STR(MoveAbsolute);
         TO_STR(SpawnEntity);
+        TO_STR(Filler);
         default: 
             os << "Unknown EventType";
             break;

--- a/src/shared/game/event.cpp
+++ b/src/shared/game/event.cpp
@@ -21,7 +21,6 @@ std::ostream& operator<<(std::ostream& os, const EventType& type) {
         TO_STR(HorizontalKeyUp);
         TO_STR(MoveAbsolute);
         TO_STR(SpawnEntity);
-        TO_STR(Filler);
         default: 
             os << "Unknown EventType";
             break;

--- a/src/shared/game/event.cpp
+++ b/src/shared/game/event.cpp
@@ -15,11 +15,8 @@ std::ostream& operator<<(std::ostream& os, const EventType& type) {
     switch (type) {
         TO_STR(LobbyAction);
         TO_STR(LoadGameState);
-        TO_STR(VerticalKeyDown);
-        TO_STR(HorizontalKeyDown);
-        TO_STR(VerticalKeyUp);
-        TO_STR(HorizontalKeyUp);
-        TO_STR(Jump);
+        TO_STR(StartAction);
+        TO_STR(StopAction);
         TO_STR(MoveAbsolute);
         TO_STR(SpawnEntity);
     default:

--- a/src/shared/game/event.cpp
+++ b/src/shared/game/event.cpp
@@ -15,8 +15,10 @@ std::ostream& operator<<(std::ostream& os, const EventType& type) {
     switch (type) {
         TO_STR(LobbyAction);
         TO_STR(LoadGameState);
-        TO_STR(MoveRelative);
-        TO_STR(MoveKeyUp);
+        TO_STR(VerticalKeyDown);
+        TO_STR(HorizontalKeyDown);
+        TO_STR(VerticalKeyUp);
+        TO_STR(HorizontalKeyUp);
         TO_STR(MoveAbsolute);
         TO_STR(SpawnEntity);
         TO_STR(Filler);

--- a/src/shared/game/event.cpp
+++ b/src/shared/game/event.cpp
@@ -13,6 +13,7 @@ std::ostream& operator<<(std::ostream& os, const Event& evt) {
 
 std::ostream& operator<<(std::ostream& os, const EventType& type) {
     switch (type) {
+        TO_STR(ChangeFacing);
         TO_STR(LobbyAction);
         TO_STR(LoadGameState);
         TO_STR(StartAction);


### PR DESCRIPTION
- Implement player movement in 3d space using StartAction/StopAction Events.
- This movement is integrated with the camera, so it can act as the "player."
- The speed, gravity coefficients can be modified in include/server/constants.hpp.
- The hardcoded "room" in the server.cpp file has been modified to render as scaled cubes.

Arrow keys to move.
Space bar to jump.
Left Shift to sprint.
Mouse to look around.

* Currently, pressing left, then pressing right would make the player stop. 