### PR TITLE
Initial `SolidSurface` Implementation

### DIFF
--- a/dependencies/boost/CMakeLists.txt
+++ b/dependencies/boost/CMakeLists.txt
@@ -10,7 +10,7 @@ FetchContent_Declare(
     Boost
     GIT_REPOSITORY https://github.com/boostorg/boost.git
     GIT_PROGRESS TRUE
-    GIT_TAG boost-1.85.0
+    GIT_TAG boost-1.82.0
 )
 FetchContent_MakeAvailable(Boost)
 

--- a/dependencies/boost/CMakeLists.txt
+++ b/dependencies/boost/CMakeLists.txt
@@ -10,7 +10,7 @@ FetchContent_Declare(
     Boost
     GIT_REPOSITORY https://github.com/boostorg/boost.git
     GIT_PROGRESS TRUE
-    GIT_TAG boost-1.82.0
+    GIT_TAG boost-1.85.0
 )
 FetchContent_MakeAvailable(Boost)
 

--- a/include/server/game/objectmanager.hpp
+++ b/include/server/game/objectmanager.hpp
@@ -4,6 +4,7 @@
 
 #include "server/game/object.hpp"
 #include "server/game/item.hpp"
+#include "server/game/solidsurface.hpp"
 
 #include "shared/utilities/smartvector.hpp"
 
@@ -57,6 +58,14 @@ public:
 	 * instance.
 	 */
 	SmartVector<Item*> getItems();
+
+	/**
+	 * @brief Get a list of all SolidSurfaces in this game instance at the
+	 * current timestep.
+	 * @return SmartVector of SolidSurface pointers of all SolidSurface objects
+	 * in the game instance.
+	 */
+	SmartVector<SolidSurface*> getSolidSurfaces();
 
 	/*	SharedGameState generation	*/
 	
@@ -115,7 +124,12 @@ private:
 	SmartVector<Object*> base_objects;
 
 	/**
-	 * @brief SmartVector of Item pointers to all items ObjectType::Item.
+	 * @brief SmartVector of Item pointers to all Item objects.
 	 */
-	SmartVector<Item*> base_items;
+	SmartVector<Item*> items;
+
+	/**
+	 * @brief SmartVector of SolidSurface pointers to all SolidSurface objects.
+	 */
+	SmartVector<SolidSurface*> solid_surfaces;
 };

--- a/include/server/game/solidsurface.hpp
+++ b/include/server/game/solidsurface.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "server/game/object.hpp"
+#include "shared/game/sharedobject.hpp"
+
+class SolidSurface : public Object {
+public:
+	SolidSurface();
+
+	~SolidSurface();
+
+	SharedSolidSurface shared{};
+
+	virtual SharedObject toShared() override;
+};

--- a/include/shared/game/sharedobject.hpp
+++ b/include/shared/game/sharedobject.hpp
@@ -13,7 +13,9 @@
  * class names in the inheritance tree in which Object is the root.
  */
 enum class ObjectType {
-	Object	//	Generic object type (base class)
+	Object,	//	Generic object type (base class)
+	Item,
+	SolidSurface
 };
 
 /**
@@ -26,6 +28,10 @@ std::string objectTypeString(ObjectType type);
 struct Stats {
 	float health;
 	float speed;
+
+	DEF_SERIALIZE(Archive& ar, const unsigned int version) {
+		ar& health& speed;
+	}
 };
 
 struct ItemInfo {
@@ -36,6 +42,34 @@ struct ItemInfo {
 	float scalar;
 	float timer;
 	ItemType type;
+
+	DEF_SERIALIZE(Archive& ar, const unsigned int version) {
+		ar& held& used& scalar& timer& type;
+	}
+};
+
+enum class SurfaceType {
+	Wall,
+	Floor,
+	Ceiling
+};
+
+struct SharedSolidSurface {
+	/**
+	 * @brief Dimensions of the solid surface in 3 dimensions. The position of
+	 * the SolidSurface object is at the center of the object.
+	 */
+	glm::vec3 dimensions;
+
+	/**
+	 * @brief Type of solid surface, e.g. wall, floor, ceiling, etc.(relevant
+	 * for rendering)
+	 */
+	SurfaceType surfaceType;
+
+	DEF_SERIALIZE(Archive& ar, const unsigned int version) {
+		ar& dimensions& surfaceType;
+	}
 };
 
 struct SharedPhysics {
@@ -48,6 +82,10 @@ struct SharedPhysics {
 	 * @brief 3-D vector that denotes this object's facing direction.
 	 */
 	glm::vec3 facing;
+
+	DEF_SERIALIZE(Archive& ar, const unsigned int version) {
+		ar& position& facing;
+	}
 };
 
 /**
@@ -62,12 +100,13 @@ public:
 
 	std::optional<Stats> stats;	
 	std::optional<ItemInfo> iteminfo;
+	std::optional<SharedSolidSurface> solidSurface;
 
 	SharedObject() {} // cppcheck-suppress uninitMemberVar
 	~SharedObject() {}
-
+	 
 	DEF_SERIALIZE(Archive& ar, const unsigned int version) {
-		ar& globalID & type& physics.position & physics.facing;
+		ar& globalID & type& physics & stats & iteminfo & solidSurface;
 	}
 private:
 };

--- a/include/shared/game/sharedobject.hpp
+++ b/include/shared/game/sharedobject.hpp
@@ -98,9 +98,9 @@ public:
 	ObjectType type;
 	SharedPhysics physics;
 
-	std::optional<Stats> stats;	
-	std::optional<ItemInfo> iteminfo;
-	std::optional<SharedSolidSurface> solidSurface;
+	boost::optional<Stats> stats;	
+	boost::optional<ItemInfo> iteminfo;
+	boost::optional<SharedSolidSurface> solidSurface;
 
 	SharedObject() {} // cppcheck-suppress uninitMemberVar
 	~SharedObject() {}

--- a/include/shared/utilities/serialize_macro.hpp
+++ b/include/shared/utilities/serialize_macro.hpp
@@ -10,6 +10,7 @@
 #include <boost/serialization/unique_ptr.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
+#include <boost/serialization/optional.hpp>
 
 // Helper macro to reduce boilerplate in making boost::serialize-able structs
 #define DEF_SERIALIZE \

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -8,6 +8,7 @@ set(FILES
     game/spherecollider.cpp
     game/creature.cpp
     game/item.cpp
+    game/solidsurface.cpp
     game/object.cpp
     game/servergamestate.cpp
     game/objectmanager.cpp

--- a/src/server/game/item.cpp
+++ b/src/server/game/item.cpp
@@ -1,6 +1,16 @@
 #include "server/game/item.hpp"
 #include "shared/game/sharedobject.hpp"
 
+/*  Constructors and Destructors    */
+Item::Item() : Object(ObjectType::Item) {
+
+}
+
+Item::~Item() {
+
+}
+
+/*	SharedGameState generation	*/
 SharedObject Item::toShared() {
     auto so = Object::toShared();
     so.iteminfo = this->iteminfo;

--- a/src/server/game/objectmanager.cpp
+++ b/src/server/game/objectmanager.cpp
@@ -10,7 +10,7 @@ ObjectManager::ObjectManager() {
 
 	//	Initialize type-specific SmartVectors
 	this->base_objects = SmartVector<Object*>();
-	this->base_items = SmartVector<Item*>();
+	this->items = SmartVector<Item*>();
 }
 
 ObjectManager::~ObjectManager() {
@@ -25,23 +25,54 @@ EntityID ObjectManager::createObject(ObjectType type) {
 	SpecificID typeID;
 
 	switch (type) {
-	case ObjectType::Object:
-		//	Create a new object of type Object
-		Object* object = new Object(ObjectType::Object);
+		case ObjectType::Object: {
+			//	Create a new object of type Object
+			Object* object = new Object(ObjectType::Object);
 
-		//	TODO: Maybe change SmartVector's index return value? size_t is
-		//	larger than uint32 (which is what SpecificID and EntityID are
-		//	defined as)
-		//	Push to type-specific base_objects vector
-		typeID = (SpecificID) this->base_objects.push(object);
+			//	TODO: Maybe change SmartVector's index return value? size_t is
+			//	larger than uint32 (which is what SpecificID and EntityID are
+			//	defined as)
+			//	Push to type-specific base_objects vector
+			typeID = (SpecificID)this->base_objects.push(object);
 
-		//	Push to global objects vector
-		globalID = (EntityID) this->objects.push(object);
+			//	Push to global objects vector
+			globalID = (EntityID)this->objects.push(object);
 
-		//	Set object's type and global IDs
-		object->typeID = typeID;
-		object->globalID = globalID;
-		break;
+			//	Set object's type and global IDs
+			object->typeID = typeID;
+			object->globalID = globalID;
+			break;
+		}
+		case ObjectType::Item: {
+			//	Create a new object of type Item
+			Item* item = new Item();
+
+			//	Push to type-specific items vector
+			typeID = (SpecificID)this->items.push(item);
+
+			//	Push to global objects vector
+			globalID = (EntityID)this->objects.push(item);
+
+			//	Set items' type and global IDs
+			item->typeID = typeID;
+			item->globalID = globalID;
+			break;
+		}
+		case ObjectType::SolidSurface: {
+			//	Create a new object of type SolidSurface
+			SolidSurface* solidSurface = new SolidSurface();
+
+			//	Push to type-specific solid_surfaces vector
+			typeID = (SpecificID)this->solid_surfaces.push(solidSurface);
+
+			//	Push to global objects vector
+			globalID = (EntityID)this->objects.push(solidSurface);
+
+			//	Set solidSurface's type and global IDs
+			solidSurface->typeID = typeID;
+			solidSurface->globalID = globalID;
+			break;
+		}
 	}
 
 	//	Return new object's global EntityID
@@ -86,7 +117,11 @@ SmartVector<Object*> ObjectManager::getObjects() {
 }
 
 SmartVector<Item*> ObjectManager::getItems() {
-	return this->base_items;
+	return this->items;
+}
+
+SmartVector<SolidSurface*> ObjectManager::getSolidSurfaces() {
+	return this->solid_surfaces;
 }
 
 /*	SharedGameState generation	*/

--- a/src/server/game/solidsurface.cpp
+++ b/src/server/game/solidsurface.cpp
@@ -1,0 +1,17 @@
+#include "server/game/solidsurface.hpp"
+
+/*	Constructors and Destructors	*/
+SolidSurface::SolidSurface() : Object(ObjectType::SolidSurface) {
+
+}
+
+SolidSurface::~SolidSurface() {}
+
+/*	SharedGameState generation	*/
+SharedObject SolidSurface::toShared() {
+	SharedObject shared = Object::toShared();
+
+	shared.solidSurface = this->shared;
+
+	return shared;
+}

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -33,6 +33,53 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
      state(ServerGameState(GamePhase::LOBBY, config))
 {
     state.objects.createObject(ObjectType::Object);
+
+    //  Create a room
+    EntityID wall1ID = state.objects.createObject(ObjectType::SolidSurface);
+    EntityID wall2ID = state.objects.createObject(ObjectType::SolidSurface);
+    EntityID wall3ID = state.objects.createObject(ObjectType::SolidSurface);
+    EntityID wall4ID = state.objects.createObject(ObjectType::SolidSurface);
+    EntityID floorID = state.objects.createObject(ObjectType::SolidSurface);
+
+    //  Specify wall positions
+    //  Configuration: 40 (x) x 32 (y) room example
+    //  ##1##
+    //  #   #
+    //  2   3
+    //  #   #
+    //  ##4##
+
+    SolidSurface* wall1 = (SolidSurface*)state.objects.getObject(wall1ID);
+    SolidSurface* wall2 = (SolidSurface*)state.objects.getObject(wall2ID);
+    SolidSurface* wall3 = (SolidSurface*)state.objects.getObject(wall3ID);
+    SolidSurface* wall4 = (SolidSurface*)state.objects.getObject(wall4ID);
+    SolidSurface* floor = (SolidSurface*)state.objects.getObject(floorID);
+
+    //  Wall1 has dimensions (40, 1, 4) and position (0, 15.5, 2)
+    wall1->shared.dimensions = glm::vec3(40, 1, 4);
+    wall1->physics.shared.position = glm::vec3(0, 15.5, 2);
+    wall1->physics.movable = false;
+
+    //  Wall2 has dimensions (30, 1, 4) and position (-19.5, 0, 2)
+    wall2->shared.dimensions = glm::vec3(30, 1, 4);
+    wall2->physics.shared.position = glm::vec3(-19.5, 0, 2);
+    wall2->physics.movable = false;
+
+    //  Wall3 has dimensions (30, 1, 4) and position (19.5, 0, 2)
+    wall3->shared.dimensions = glm::vec3(30, 1, 4);
+    wall3->physics.shared.position = glm::vec3(19.5, 0, 2);
+    wall3->physics.movable = false;
+
+    //  Wall4 has dimensions (40, 1, 4) and position (0, -15.5, 2)
+    wall4->shared.dimensions = glm::vec3(40, 1, 4);
+    wall4->physics.shared.position = glm::vec3(0, -15.5, 2);
+    wall4->physics.movable = false;
+
+    //  floor has dimensions (40, 32, 1) and position (0, 0, -0.5)
+    floor->shared.dimensions = glm::vec3(40, 32, 1);
+    floor->physics.shared.position = glm::vec3(0, 0, -0.5);
+    floor->physics.movable = false;
+
     
     _doAccept(); // start asynchronously accepting
 
@@ -44,6 +91,8 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
     }
 }
 
+//  Note: This method should probably be removed since EntityIDs for objects
+//  are assigned by the ObjectManager
 EntityID Server::genNewEID() {
     static EntityID id = 1;
     return id++;


### PR DESCRIPTION
Added a `SolidSurface` class that derives from `Object` and which is used to represent all walls, floors, and ceilings in the game. At present all `Object`s have a single anchor point which is always at their center (I have discussed this with Ted, and we'll likely change this to have two position vectors for each `Object`, one at its center and one at its lower "min" corner (from which the object extends in the positive x and y directions).

I have included a demo room in `server.cpp`.