### PR TITLE
Updated `ObjectManager` and Slight `Object`-Derived Class Refactoring

### DIFF
--- a/include/debugger/debugger.hpp
+++ b/include/debugger/debugger.hpp
@@ -257,10 +257,10 @@ public:
 		//	This command ignores arguments
 
 		//	Create a new base object in the game state
-		unsigned int globalID = state.objects.createObject(ObjectType::Object);
-		Object* obj = state.objects.getObject(globalID);
+		SpecificID typeID = state.objects.createObject(ObjectType::Object);
+		Object* obj = state.objects.getBaseObject(typeID);
 
-		std::cout << "Created new object (global id " << globalID << ")" << std::endl;
+		std::cout << "Created new object (global id " << obj->globalID << ")" << std::endl;
 	}
 };
 

--- a/include/server/game/creature.hpp
+++ b/include/server/game/creature.hpp
@@ -6,8 +6,8 @@
 
 class Creature : public Object {
 public:
-	Creature(ObjectType type);
-	~Creature();
+	explicit Creature(ObjectType type);
+	virtual ~Creature();
 
 	virtual SharedObject toShared() override;
 private:

--- a/include/server/game/creature.hpp
+++ b/include/server/game/creature.hpp
@@ -6,6 +6,8 @@
 
 class Creature : public Object {
 public:
+	SharedStats shared;
+
 	explicit Creature(ObjectType type);
 	virtual ~Creature();
 

--- a/include/server/game/creature.hpp
+++ b/include/server/game/creature.hpp
@@ -6,7 +6,7 @@
 
 class Creature : public Object {
 public:
-	SharedStats shared;
+	SharedStats shared{};
 
 	explicit Creature(ObjectType type);
 	virtual ~Creature();

--- a/include/server/game/enemy.hpp
+++ b/include/server/game/enemy.hpp
@@ -5,15 +5,13 @@
 #include "server/game/creature.hpp"
 #include "shared/game/sharedobject.hpp"
 
-struct EnemyStats {
-	int health;
-
-
-};
+//struct EnemyStats {
+//	int health;
+//};
 
 class Enemy : public Creature {
 public:
-	EnemyStats stats;
+	//EnemyStats stats;
 
 	// list of abilities
 

--- a/include/server/game/item.hpp
+++ b/include/server/game/item.hpp
@@ -7,7 +7,7 @@
 class Item : public Object {
 public:
 
-	ItemInfo iteminfo;
+	SharedItemInfo iteminfo;
 
 	Item();
 	~Item();

--- a/include/server/game/item.hpp
+++ b/include/server/game/item.hpp
@@ -7,7 +7,7 @@
 class Item : public Object {
 public:
 
-	SharedItemInfo iteminfo;
+	SharedItemInfo iteminfo{};
 
 	Item();
 	~Item();

--- a/include/server/game/object.hpp
+++ b/include/server/game/object.hpp
@@ -72,7 +72,7 @@ public:
 	Physics physics;
 
 	explicit Object(ObjectType type);
-	~Object();
+	virtual ~Object();
 
 	/**
 	 * @brief Generates a SharedObject representation of this object.

--- a/include/server/game/objectmanager.hpp
+++ b/include/server/game/objectmanager.hpp
@@ -25,9 +25,9 @@ public:
 	 * NOT do this!)
 	 * 
 	 * @param type the type of object to create
-	 * @return the EntityID of the newly created object
+	 * @return the SpecificID of the newly created object
 	 */
-	EntityID createObject(ObjectType type);
+	SpecificID createObject(ObjectType type);
 
 	/**
 	 * @brief Attempts to remove an object with the given EntityID.
@@ -38,12 +38,63 @@ public:
 	bool removeObject(EntityID globalID);
 
 	/**
+	 * @brief Attempts to remove an object pointed to by the pointer pointed to
+	 * by the given Object double pointer.
+	 * If successful, it will set the given Object pointer to nullptr. (use to
+	 * avoid dangling Object pointers)
+	 * @param object_dbl_ptr Double pointer to the object to remove
+	 * @return true if the object was successfully removed and false otherwise.
+	 */
+	bool removeObject(Object** object_dbl_ptr);
+
+	/**
 	 * @brief Attempts to retrieve the object with the given EntityID.
 	 * @param globalID EntityID of the object to retrieve
 	 * @return A pointer to the object with the given EntityID or nullptr if
 	 * none exists.
 	 */
 	Object* getObject(EntityID globalID);
+
+	/*	SpecificID object getters by type	*/
+
+	/**
+	 * @brief Attempts to retrieve the Object with the given SpecificID.
+	 * @param base_objectID SpecificID of the Object to retrieve
+	 * @return A pointer to the Object with the given SpecificID or nullptr if
+	 * none exists.
+	 */
+	Object* getBaseObject(SpecificID base_objectID);
+
+	/**
+	 * @brief Attempts to retrieve the Item with the given SpecificID.
+	 * @param itemID SpecificID of the Item to retrieve
+	 * @return A pointer to the Item with the given SpecificID or nullptr if
+	 * none exists.
+	 */
+	Item* getItem(SpecificID itemID);
+
+	/**
+	 * @brief Attempts to retrieve the SolidSurface with the given SpecificID.
+	 * @param surfaceID SpecificID of the SolidSurface to retrieve
+	 * @return A pointer to the SolidSurface with the given SpecificID or
+	 * nullptr if none exists.
+	 */
+	SolidSurface* getSolidSurface(SpecificID surfaceID);
+
+	/**
+	 * @brief Attempts to retrieve the Player with the given SpecificID.
+	 * @param playerID SpecificID of the Player to retrieve
+	 * @return A pointer to the Player with the given SpecificID or nullptr if
+	 * none exists.
+	 */
+	Player* getPlayer(SpecificID playerID);
+
+	/**
+	 * @brief Attempts to retrieve the Enemy with the given SpecificID.
+	 * @param enemyID SpecificID of the Enemy to retrieve
+	 * @return A pointer 
+	 */
+	Enemy* getEnemy(SpecificID enemyID);
 
 	/**
 	 * @brief Get a list of all objects in this game instance at the current
@@ -68,6 +119,22 @@ public:
 	 * in the game instance.
 	 */
 	SmartVector<SolidSurface*> getSolidSurfaces();
+
+	/**
+	 * @brief Get a list of all Players in this game instance at the current
+	 * timestep.
+	 * @return SmartVector of Player pointers of all Player objects in the game
+	 * instance.
+	 */
+	SmartVector<Player*> getPlayers();
+
+	/**
+	 * @brief Get a list of all Enemies in this game instance at the current
+	 * timestep.
+	 * @return SmartVector of Enemy pointers of all Enemy objects in the game
+	 * instance.
+	 */
+	SmartVector<Enemy*> getEnemies();
 
 	/*	SharedGameState generation	*/
 	
@@ -115,7 +182,7 @@ private:
 	 * that is, the Object pointer at index x points to the Object with global 
 	 * EntityID x.
 	 */
-	SmartVector<Object*> objects;
+	SmartVector<Object *> objects;
 
 	/*	Type-specific object smart vectors	*/
 	
@@ -123,27 +190,27 @@ private:
 	 * @brief SmartVector of Object pointers to all objects whose ObjectType is
 	 * ObjectType::Object.
 	 */
-	SmartVector<Object*> base_objects;
+	SmartVector<Object *> base_objects;
 
 	/**
 	 * @brief SmartVector of Item pointers to all Item objects.
 	 */
-	SmartVector<Item*> items;
+	SmartVector<Item *> items;
 
 	/**
 	 * @brief SmartVector of SolidSurface pointers to all SolidSurface objects.
 	 */
-	SmartVector<SolidSurface*> solid_surfaces;
+	SmartVector<SolidSurface *> solid_surfaces;
 
 	/**
 	 * @brief SmartVector of Player pointers to all objects whose ObjectType is
 	 * ObjectType::Player.
 	 */
-	SmartVector<Player*> player_objects;
+	SmartVector<Player *> players;
 
 	/**
 	 * @brief SmartVector of Enemy pointers to all objects whose ObjectType is
 	 * ObjectType::Enemy.
 	 */
-	SmartVector<Enemy*> enemy_objects;
+	SmartVector<Enemy *> enemies;
 };

--- a/include/server/game/player.hpp
+++ b/include/server/game/player.hpp
@@ -5,16 +5,16 @@
 #include "server/game/creature.hpp"
 #include "shared/game/sharedobject.hpp"
 
-struct PlayerStats {
-	int health;
-
-
-};
+//struct PlayerStats {
+//	int health;
+//
+//
+//};
 
 
 class Player : public Creature {
 public:
-	PlayerStats stats;
+	//PlayerStats stats;
 
 	// player can have items
 

--- a/include/server/game/servergamestate.hpp
+++ b/include/server/game/servergamestate.hpp
@@ -56,7 +56,7 @@ public:
 	 * @param maze_file Name of maze file to load. (should be in maps/
 	 * directory).
 	 */
-	ServerGameState(GameConfig config);
+	explicit ServerGameState(GameConfig config);
 
 	~ServerGameState();
 

--- a/include/shared/game/sharedobject.hpp
+++ b/include/shared/game/sharedobject.hpp
@@ -26,7 +26,7 @@ enum class ObjectType {
  */
 std::string objectTypeString(ObjectType type);
 
-struct Stats {
+struct SharedStats {
 	float health;
 	float speed;
 
@@ -35,7 +35,7 @@ struct Stats {
 	}
 };
 
-struct ItemInfo {
+struct SharedItemInfo {
 	enum ItemType { healing, swiftness, invisible, key };
 
 	bool held; // for rendering
@@ -99,8 +99,8 @@ public:
 	ObjectType type;
 	SharedPhysics physics;
 
-	boost::optional<Stats> stats;	
-	boost::optional<ItemInfo> iteminfo;
+	boost::optional<SharedStats> stats;	
+	boost::optional<SharedItemInfo> iteminfo;
 	boost::optional<SharedSolidSurface> solidSurface;
 
 	SharedObject() {} // cppcheck-suppress uninitMemberVar

--- a/src/server/game/objectmanager.cpp
+++ b/src/server/game/objectmanager.cpp
@@ -5,12 +5,12 @@
 /*	Constructors and Destructors	*/
 
 ObjectManager::ObjectManager() {
-	//	Initialize global SmartVector
-	this->objects = SmartVector<Object*>();
+	////	Initialize global SmartVector
+	//this->objects = SmartVector<Object*>();
 
-	//	Initialize type-specific SmartVectors
-	this->base_objects = SmartVector<Object*>();
-	this->items = SmartVector<Item*>();
+	////	Initialize type-specific SmartVectors
+	//this->base_objects = SmartVector<Object*>();
+	//this->items = SmartVector<Item*>();
 }
 
 ObjectManager::~ObjectManager() {
@@ -19,101 +19,80 @@ ObjectManager::~ObjectManager() {
 
 /*	Object CRUD methods	*/
 
-EntityID ObjectManager::createObject(ObjectType type) {
+SpecificID ObjectManager::createObject(ObjectType type) {
 	//	Create a new object with the given type
 	EntityID globalID;
 	SpecificID typeID;
 
 	switch (type) {
-	case ObjectType::Object: {
-		//	Create a new object of type Object
-		Object* object = new Object(ObjectType::Object);
+		case ObjectType::Item: {
+			//	Create a new object of type Item
+			Item* item = new Item();
 
-		//	TODO: Maybe change SmartVector's index return value? size_t is
-		//	larger than uint32 (which is what SpecificID and EntityID are
-		//	defined as)
-		//	Push to type-specific base_objects vector
-		typeID = (SpecificID)this->base_objects.push(object);
+			//	Push to type-specific items vector
+			typeID = (SpecificID)this->items.push(item);
 
-		//	Push to global objects vector
-		globalID = (EntityID)this->objects.push(object);
+			//	Push to global objects vector
+			globalID = (EntityID)this->objects.push(item);
 
-		//	Set object's type and global IDs
-		object->typeID = typeID;
-		object->globalID = globalID;
-		break;
-	}
-	case ObjectType::Item: {
-		//	Create a new object of type Item
-		Item* item = new Item();
+			//	Set items' type and global IDs
+			item->typeID = typeID;
+			item->globalID = globalID;
+			break;
+		}
+		case ObjectType::SolidSurface: {
+			//	Create a new object of type SolidSurface
+			SolidSurface* solidSurface = new SolidSurface();
 
-		//	Push to type-specific items vector
-		typeID = (SpecificID)this->items.push(item);
+			//	Push to type-specific solid_surfaces vector
+			typeID = (SpecificID)this->solid_surfaces.push(solidSurface);
 
-		//	Push to global objects vector
-		globalID = (EntityID)this->objects.push(item);
+			//	Push to global objects vector
+			globalID = (EntityID)this->objects.push(solidSurface);
 
-		//	Set items' type and global IDs
-		item->typeID = typeID;
-		item->globalID = globalID;
-		break;
-	}
-	case ObjectType::SolidSurface: {
-		//	Create a new object of type SolidSurface
-		SolidSurface* solidSurface = new SolidSurface();
+			//	Set solidSurface's type and global IDs
+			solidSurface->typeID = typeID;
+			solidSurface->globalID = globalID;
+			break;
+		}
+		case ObjectType::Player: {
+			//	Create a new object of type Player
+			Player* player = new Player();
 
-		//	Push to type-specific solid_surfaces vector
-		typeID = (SpecificID)this->solid_surfaces.push(solidSurface);
+			//	Push to type-specific players vector
+			typeID = (SpecificID)this->players.push(player);
 
-		//	Push to global objects vector
-		globalID = (EntityID)this->objects.push(solidSurface);
+			//	Push to global objects vector
+			globalID = (EntityID)this->objects.push(player);
 
-		//	Set solidSurface's type and global IDs
-		solidSurface->typeID = typeID;
-		solidSurface->globalID = globalID;
-		break;
-	}
-	case ObjectType::Player: {
-		
-		//	Create a new object of type Player
-		Player* player = new Player();
+			//	Set object's type and global IDs
+			player->typeID = typeID;
+			player->globalID = globalID;
+			break;
+		}
+		case ObjectType::Object:
+		default: {
+			//	Create a new object of type Object
+			Object* object = new Object(ObjectType::Object);
 
-		//	TODO: Maybe change SmartVector's index return value? size_t is
-		//	larger than uint32 (which is what SpecificID and EntityID are
-		//	defined as)
-		//	Push to type-specific base_objects vector
-		typeID = (SpecificID)this->player_objects.push(player);
+			//	TODO: Maybe change SmartVector's index return value? size_t is
+			//	larger than uint32 (which is what SpecificID and EntityID are
+			//	defined as)
+			//	Push to type-specific base_objects vector
+			typeID = (SpecificID)this->base_objects.push(object);
 
-		//	Push to global objects vector
-		globalID = (EntityID)this->objects.push(player);
+			//	Push to global objects vector
+			globalID = (EntityID)this->objects.push(object);
 
-		//	Set object's type and global IDs
-		player->typeID = typeID;
-		player->globalID = globalID;
-		break;
-	}
-	default: {
-		//	Create a new object of type Object
-		Object* object = new Object(ObjectType::Object);
-
-		//	TODO: Maybe change SmartVector's index return value? size_t is
-		//	larger than uint32 (which is what SpecificID and EntityID are
-		//	defined as)
-		//	Push to type-specific base_objects vector
-		typeID = (SpecificID)this->base_objects.push(object);
-
-		//	Push to global objects vector
-		globalID = (EntityID)this->objects.push(object);
-
-		//	Set object's type and global IDs
-		object->typeID = typeID;
-		object->globalID = globalID;
-		break;
-	}
+			//	Set object's type and global IDs
+			object->typeID = typeID;
+			object->globalID = globalID;
+			break;
+		}
 	}
 
-	//	Return new object's global EntityID
-	return globalID;
+	//	Return new object's specificID
+	return typeID;
 }
 
 bool ObjectManager::removeObject(EntityID globalID) {
@@ -143,14 +122,55 @@ bool ObjectManager::removeObject(EntityID globalID) {
 	return true;
 }
 
-Object* ObjectManager::getObject(EntityID globalID) {
-	Object* object = this->objects.get(globalID);
+bool ObjectManager::removeObject(Object** object_dbl_ptr) {
+	//	Check that the given object double pointer isn't nullptr or that the
+	//	object pointer it points to isn't nullptr
+	if (object_dbl_ptr == nullptr || *object_dbl_ptr == nullptr)
+		return false;
 
-	return object;
+	//	Object pointer points to an Object - attempt to remove it
+	Object* object = *object_dbl_ptr;
+
+	//	Get EntityID of this object
+	EntityID globalID = object->globalID;
+
+	if (this->removeObject(globalID)) {
+		//	Set object pointer to nullptr (avoids dangling pointers)
+		*object_dbl_ptr = nullptr;
+		return true;
+	}
+
+	//	Failed to remove object
+	return false;
+}
+
+Object* ObjectManager::getObject(EntityID globalID) {
+	return this->objects.get(globalID);
 }
 
 SmartVector<Object*> ObjectManager::getObjects() {
 	return this->objects;
+}
+
+/*	SpecificID object getters by type	*/
+Object* ObjectManager::getBaseObject(SpecificID base_objectID) {
+	return this->base_objects.get(base_objectID);
+}
+
+Item* ObjectManager::getItem(SpecificID itemID) {
+	return this->items.get(itemID);
+}
+
+SolidSurface* ObjectManager::getSolidSurface(SpecificID surfaceID) {
+	return this->solid_surfaces.get(surfaceID);
+}
+
+Player* ObjectManager::getPlayer(SpecificID playerID) {
+	return this->players.get(playerID);
+}
+
+Enemy* ObjectManager::getEnemy(SpecificID enemyID) {
+	return this->enemies.get(enemyID);
 }
 
 SmartVector<Item*> ObjectManager::getItems() {
@@ -159,6 +179,14 @@ SmartVector<Item*> ObjectManager::getItems() {
 
 SmartVector<SolidSurface*> ObjectManager::getSolidSurfaces() {
 	return this->solid_surfaces;
+}
+
+SmartVector<Player*> ObjectManager::getPlayers() {
+	return this->players;
+}
+
+SmartVector<Enemy*> ObjectManager::getEnemies() {
+	return this->enemies;
 }
 
 /*	SharedGameState generation	*/

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -347,11 +347,11 @@ void ServerGameState::loadMaze() {
 
 	//	Step 5:	Add floor and ceiling SolidSurfaces.
 
-	EntityID floorID = this->objects.createObject(ObjectType::SolidSurface);
-	EntityID ceilingID = this->objects.createObject(ObjectType::SolidSurface);
+	SpecificID floorID = this->objects.createObject(ObjectType::SolidSurface);
+	SpecificID ceilingID = this->objects.createObject(ObjectType::SolidSurface);
 
-	SolidSurface* floor = (SolidSurface*)this->objects.getObject(floorID);
-	SolidSurface* ceiling = (SolidSurface*)this->objects.getObject(ceilingID);
+	SolidSurface* floor = this->objects.getSolidSurface(floorID);
+	SolidSurface* ceiling = this->objects.getSolidSurface(ceilingID);
 
 	//	Set floor and ceiling's x and z dimensions equal to grid dimensions
 	
@@ -388,14 +388,13 @@ void ServerGameState::loadMaze() {
 			switch (cell->type) {
 				case CellType::Wall: {
 					//	Create a new Wall object
-					EntityID wallID = 
+					SpecificID wallID = 
 						this->objects.createObject(ObjectType::SolidSurface);
 
 					//	TODO: Shouldn't this use the typeID? Change
 					//	createObject() to return the typeID of an object and
 					//	add specific object getters based on their types.
-					SolidSurface* wall = (SolidSurface *)
-						this->objects.getObject(wallID);
+					SolidSurface* wall = this->objects.getSolidSurface(wallID);
 
 					wall->shared.dimensions =
 						glm::vec3(this->grid.getGridCellWidth(),

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -28,7 +28,7 @@ ServerGameState::ServerGameState(GamePhase start_phase)
 	this->phase = start_phase;
 }
 
-ServerGameState::ServerGameState(GamePhase start_phase, GameConfig config)
+ServerGameState::ServerGameState(GamePhase start_phase, GameConfig config) // cppcheck-suppress passedByValue
 	: ServerGameState(config) {
 	this->phase = start_phase;
 }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -32,8 +32,8 @@ Server::Server(boost::asio::io_context& io_context, GameConfig config)
      world_eid(0),
      state(ServerGameState(GamePhase::LOBBY, config))
 {
-    EntityID cubeID = state.objects.createObject(ObjectType::Object);
-    Object* cube = state.objects.getObject(cubeID);
+    SpecificID cubeID = state.objects.createObject(ObjectType::Object);
+    Object* cube = state.objects.getBaseObject(cubeID);
     cube->physics.movable = false;
 
     
@@ -239,7 +239,9 @@ std::shared_ptr<Session> Server::_handleNewSession(boost::asio::ip::address addr
 
     // Brand new connection
     // TODO: reject connection if not in LOBBY GamePhase
-    EntityID id = this->state.objects.createObject(ObjectType::Player);
+    SpecificID typeID = this->state.objects.createObject(ObjectType::Player);
+    Player* player = this->state.objects.getPlayer(typeID);
+    EntityID id = player->globalID;
     auto session = std::make_shared<Session>(std::move(this->socket),
         SessionInfo({}, id));
 


### PR DESCRIPTION
Updated `ObjectManager` class:
- Added type-specific object getters
    - E.g., `Player * getPlayer(SpecificID playerID)`
    - Added a getter for each type-specific `SmartVector`
- Updated `ObjectManager::createObject()` to return the newly created object's type-specific ID so that it can be easily accessed after creation using the type-specific object getters without casting.
    - E.g., instead of:
        - `EntityID playerID = this->objects.createObject(ObjectType::Player);`
        - `Player * player = (Player *) this->objects.getObject(playerID);
    - We can now use:
        - `SpecificID playerID = this->objects.createObject(ObjectType::Player);`
        - `Player * player = this->objects.getPlayer(playerID);`
- Added an overload to `ObjectManager::removeObject()` to automatically set `Object` pointer to `nullptr` (new overload is `ObjectManager::removeObject(Object ** object_dbl_ptr)`
    - I.e., instead of:
        - `Object * object = ...; // create object`
        - `// ... use object`
        - `this->objects.removeObject(object->globalID);`
        - `// object pointer is now dangling, must set to nullptr explicitly`
        - `object = nullptr;`
    - We can use:
        - `Object * object = ...; // create object`
        - `// ... use object`
        - `this->objects.removeObject(&object);`
        - `// object is now nullptr`

Renamed `ItemInfo` and `Stats` to `SharedItemInfo` and `SharedStats` to clarify their shared nature.

For now, added a `SharedStats` field to `Creature` and commented out the `PlayerStats` and `EnemyStats` structs as they contain a subset of `SharedStats`. However, once `Player` and `Enemy` have stats that should not be added to `Creature`, these fields should go in `PlayerStats` and `EnemyStats`. If any of these will be shared, a `SharedPlayerStats` and/or `SharedEnemyStats` struct should be defined in `sharedobject.hpp` and placed in `Player` and `Enemy`. Then if there are any server-only properties, then a `PlayerStats` or `EnemyStats` struct should be made in `player.hpp` or `enemy.hpp` and contain the `SharedPlayerStats` or `SharedEnemyStats` struct as a `shared` field.

Closes #79 