### PR TITLE
Fix memory leak (number 1)

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -360,7 +360,7 @@ void Client::draw() {
                 break;
             }
             case ObjectType::SolidSurface: {
-                Cube* cube = new Cube(glm::vec3(0.4f,0.5f,0.7f));
+                auto cube = std::make_unique<Cube>(glm::vec3(0.4f,0.5f,0.7f));
                 cube->scale( sharedObject->solidSurface->dimensions);
                 cube->translateAbsolute(sharedObject->physics.position);
                 cube->draw(this->cube_shader,
@@ -368,7 +368,6 @@ void Client::draw() {
                     this->cam->getPos(),
                     glm::vec3(),
                     true);
-                delete cube;
                 break;
             }
             default:

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -368,6 +368,7 @@ void Client::draw() {
                     this->cam->getPos(),
                     glm::vec3(),
                     true);
+                delete cube;
                 break;
             }
             default:


### PR DESCRIPTION
Fixed a memory leak in the render loop for the client, which caused [# walls] Cube objects to be allocated and then never deleted each frame.

surely this will be the 1 and only memory leak we have during our entire project!