### PR TITLE
Updated StaticImg to use model matrix for transformations

### DIFF
--- a/src/client/gui/widget/staticimg.cpp
+++ b/src/client/gui/widget/staticimg.cpp
@@ -12,33 +12,14 @@ std::unique_ptr<Shader> StaticImg::shader = nullptr;
 StaticImg::StaticImg(glm::vec2 origin, gui::img::Img img):
     Widget(Type::StaticImg, origin), img(img)
 {
-    this->width = img.width;
-    this->height = img.height;
-    this->texture_id = img.texture_id;
-}
-
-StaticImg::StaticImg(gui::img::Img img):
-    StaticImg({0.0f, 0.0f}, img) {}
-
-StaticImg::~StaticImg() {
-    glDeleteVertexArrays(1, &quadVAO);
-    glDeleteBuffers(1, &VBO);
-    glDeleteBuffers(1, &EBO);
-}
-
-void StaticImg::render() {
-    // ⚠ SUS SHIT ⚠
-    float width_percent = (2.0f / (WINDOW_WIDTH)) * (img.width);
-    float height_percent = (2.0f / (WINDOW_HEIGHT)) * (img.height);
-    glm::vec2 bottom_left = (2.0f * (origin / glm::vec2(WINDOW_WIDTH, WINDOW_HEIGHT))) - glm::vec2(1.0f, 1.0f);
-
     float vertices[] = {
         // positions          // colors           // texture coords
-        bottom_left.x + width_percent,  bottom_left.y + height_percent, 0.0f,   1.0f, 0.0f, 0.0f,   1.0f, 1.0f, // top right
-        bottom_left.x + width_percent, bottom_left.y, 0.0f,   0.0f, 1.0f, 0.0f,   1.0f, 0.0f, // bottom right
-        bottom_left.x, bottom_left.y, 0.0f,   0.0f, 0.0f, 1.0f,   0.0f, 0.0f, // bottom left
-        bottom_left.x, bottom_left.y + height_percent, 0.0f,   1.0f, 1.0f, 0.0f,   0.0f, 1.0f  // top left 
+         0.5f,  0.5f, 0.0f,   1.0f, 0.0f, 0.0f,   1.0f, 1.0f, // top right
+         0.5f, -0.5f, 0.0f,   0.0f, 1.0f, 0.0f,   1.0f, 0.0f, // bottom right
+        -0.5f, -0.5f, 0.0f,   0.0f, 0.0f, 1.0f,   0.0f, 0.0f, // bottom left
+        -0.5f,  0.5f, 0.0f,   1.0f, 1.0f, 0.0f,   0.0f, 1.0f  // top left 
     };
+
     unsigned int indices[] = {
         0, 1, 3, // first triangle
         1, 2, 3  // second triangle
@@ -66,13 +47,27 @@ void StaticImg::render() {
     glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(6 * sizeof(float)));
     glEnableVertexAttribArray(2);
 
+    this->width = img.width;
+    this->height = img.height;
+    this->texture_id = img.texture_id;
+}
+
+StaticImg::StaticImg(gui::img::Img img):
+    StaticImg({0.0f, 0.0f}, img) {}
+
+StaticImg::~StaticImg() {
+    glDeleteVertexArrays(1, &quadVAO);
+    glDeleteBuffers(1, &VBO);
+    glDeleteBuffers(1, &EBO);
+}
+
+void StaticImg::render() {
+    glDisable(GL_CULL_FACE);
     StaticImg::shader->use();
 
-    // glm::mat4 projection = GUI_PROJECTION_MATRIX();
-    // shader->setMat4("projection", projection);
-    // glm::mat4 transform = glm::mat4(1.0f);
-    // // transform = glm::translate(transform, glm::vec3(this->origin.x, this->origin.y, 0));
-    // shader->setMat4("transform", transform);
+    glm::mat4 model = glm::mat4(1.0f);
+    model = glm::translate(model, glm::vec3(this->origin.x, this->origin.y, 0));
+    shader->setMat4("model", model);
 
     // glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, this->texture_id);
@@ -83,6 +78,8 @@ void StaticImg::render() {
     glBindVertexArray(0);
     glBindTexture(GL_TEXTURE_2D, 0);
     glUseProgram(0);
+
+    glEnable(GL_CULL_FACE);
 }
 
 }

--- a/src/client/shaders/img.vert
+++ b/src/client/shaders/img.vert
@@ -6,9 +6,11 @@ layout (location = 2) in vec2 aTexCoord;
 out vec3 ourColor;
 out vec2 TexCoord;
 
+uniform mat4 model;
+
 void main()
 {
-	gl_Position = vec4(aPos, 1.0);
+	gl_Position = model * vec4(aPos, 1.0);
 	ourColor = aColor;
 	TexCoord = vec2(aTexCoord.x, aTexCoord.y);
 }


### PR DESCRIPTION
Very small PR that modifies the StaticImg class to use a model matrix for transformations. Updates img.vert to include a mat4 uniform representing the model matrix.