### PR TITLE
Fix/model rotation

### DIFF
--- a/include/client/model.hpp
+++ b/include/client/model.hpp
@@ -206,7 +206,7 @@ class Model : public Renderable {
      * @param angle The angle of rotation
      * @param axis The axis of rotation 
      */
-    void rotateAbsolute(const glm::vec3& dir, const glm::vec3& axis = glm::vec3(0.0f, 1.0f, 0.0f)) override;
+    void rotateAbsolute(const glm::vec3& dir,  bool is_player = false, const glm::vec3& axis = glm::vec3(0.0f, 1.0f, 0.0f)) override;
 
     /**
      * @brief Rotates the item along the specified axis. If

--- a/include/client/renderable.hpp
+++ b/include/client/renderable.hpp
@@ -100,7 +100,7 @@ class Renderable {
      * @param angle The angle of rotation
      * @param axis The axis of rotation 
      */
-    virtual void rotateAbsolute(const glm::vec3& dir, const glm::vec3& axis = glm::vec3(0.0f, 1.0f, 0.0f));
+    virtual void rotateAbsolute(const glm::vec3& dir, bool is_player = false, const glm::vec3& axis = glm::vec3(0.0f, 1.0f, 0.0f));
 
     /**
      * @brief Rotates the item along the specified axis. If

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -660,7 +660,11 @@ void Client::geometryPass() {
                 auto player_pos = sharedObject->physics.getCenterPosition();
                 auto player_dir = sharedObject->physics.facing;
 
-                this->player_model->rotateAbsolute(player_dir);
+                if (player_dir == glm::vec3(0.0f)) {
+                    player_dir = glm::vec3(0.0f, 0.0f, 1.0f);
+                }
+                player_dir.y = 0.0f;
+                this->player_model->rotateAbsolute(glm::normalize(player_dir), true);
                 this->player_model->translateAbsolute(player_pos);
                 this->player_model->draw(
                     this->deferred_geometry_shader.get(),
@@ -689,7 +693,7 @@ void Client::geometryPass() {
                     player_dir = glm::vec3(0.0f, 0.0f, 1.0f);
                 }
                 player_dir.y = 0.0f;
-                this->player_model->rotateAbsolute(glm::normalize(player_dir));
+                this->player_model->rotateAbsolute(glm::normalize(player_dir), true);
                 this->player_model->draw(
                     this->deferred_geometry_shader.get(),
                     this->cam->getPos(),

--- a/src/client/model.cpp
+++ b/src/client/model.cpp
@@ -211,10 +211,10 @@ void Model::scaleRelative(const glm::vec3& scale) {
     }
 }
 
-void Model::rotateAbsolute(const glm::vec3& dir, const glm::vec3& axis) {
-    Renderable::rotateAbsolute(dir, axis);
+void Model::rotateAbsolute(const glm::vec3& dir, bool is_player, const glm::vec3& axis) {
+    Renderable::rotateAbsolute(dir, is_player, axis);
     for(Mesh& mesh : this->meshes) {
-        mesh.rotateAbsolute(dir, axis);
+        mesh.rotateAbsolute(dir, is_player, axis);
     }
 }
 

--- a/src/client/renderable.cpp
+++ b/src/client/renderable.cpp
@@ -39,8 +39,8 @@ void Renderable::scaleAbsolute(const glm::vec3& scale) {
     this->model[2][2] = scale.z;
 }
 
-void Renderable::rotateAbsolute(const glm::vec3& dir, const glm::vec3& axis) {
-    float r = glm::atan(-dir.z, dir.x);
+void Renderable::rotateAbsolute(const glm::vec3& dir, bool is_player, const glm::vec3& axis) {
+    float r = is_player ? glm::atan(dir.x, dir.z) : glm::atan(-dir.z, dir.x);
     this->rotation = glm::angleAxis(r, axis);
 }
 


### PR DESCRIPTION
Adds a change to Renderable::rotateAbsolute which fixes issues with player model rotation, and also preserves existing rotation logic for other models (i.e. Sungod model). To rotate player models the correct way, just `true` as a second parameter to rotateAbsolute (i.e. `player_model->rotateAbsolute(player_dir, true)`).