### PR TITLE
Fix/tick rate

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "game": {
     "maze": {
       "directory": "maps",
-      "procedural": false,
+      "procedural": true,
       "maze_file": "test/itemRoom.maze"
     }
   },

--- a/dependencies/freetype/CMakeLists.txt
+++ b/dependencies/freetype/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 FetchContent_Declare(
   freetype
-  GIT_REPOSITORY https://gitlab.freedesktop.org/freetype/freetype.git
+  GIT_REPOSITORY https://github.com/freetype/freetype.git
   GIT_TAG        VER-2-13-2
 )
 

--- a/include/shared/network/constants.hpp
+++ b/include/shared/network/constants.hpp
@@ -8,4 +8,4 @@
 // How many objects we send in one LoadGameState packet
 // If there are more objects that need to be sent, then
 // they are split up into multiple LoadGameState packets
-#define OBJECTS_PER_UPDATE 80 
+#define OBJECTS_PER_UPDATE 250

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -75,7 +75,6 @@ Client::Client(boost::asio::io_context& io_context, GameConfig config):
     lobby_finder(io_context, config),
     cam(new Camera()) {    
 
-    this->socket.set_option(boost::asio::ip::tcp::no_delay(true));
 
     //  Initialize Client's GUIState::Lobby related state
     //  Initial lobby player state is set to connected (this assumes that whenever

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -75,6 +75,8 @@ Client::Client(boost::asio::io_context& io_context, GameConfig config):
     lobby_finder(io_context, config),
     cam(new Camera()) {    
 
+    this->socket.set_option(boost::asio::ip::tcp::no_delay(true));
+
     //  Initialize Client's GUIState::Lobby related state
     //  Initial lobby player state is set to connected (this assumes that whenever
     //  GUIState is set to GUIState::Lobby, the client is connected to a lobby)

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -138,9 +138,14 @@ std::vector<SharedGameState> ServerGameState::generateSharedGameState(bool send_
 
 		int num_in_curr_update = 0;
 		for (EntityID id : this->updated_entities) {
-			SharedObject shared_obj = this->objects.getObject(id)->toShared();
 
-			curr_update.objects.insert({id, shared_obj});
+			Object* obj = this->objects.getObject(id);
+			if (obj == nullptr) {
+				curr_update.objects.insert({ id, boost::none });
+			} else {
+				curr_update.objects.insert({ id, obj->toShared() });
+			}
+
 			num_in_curr_update++;
 
 			if (num_in_curr_update >= OBJECTS_PER_UPDATE) {

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -107,7 +107,6 @@ ServerGameState::~ServerGameState() {}
 /*	SharedGameState generation	*/
 std::vector<SharedGameState> ServerGameState::generateSharedGameState(bool send_all) {
 	std::vector<SharedGameState> partial_updates;
-	auto all_objects = this->objects.toShared();
 
 	auto getUpdateTemplate = [this]() {
 		SharedGameState curr_update;
@@ -122,6 +121,8 @@ std::vector<SharedGameState> ServerGameState::generateSharedGameState(bool send_
 	};
 
 	if (send_all) {
+		auto all_objects = this->objects.toShared();
+
 		for (int i = 0; i < all_objects.size(); i += OBJECTS_PER_UPDATE) {
 			SharedGameState curr_update = getUpdateTemplate();
 
@@ -137,7 +138,9 @@ std::vector<SharedGameState> ServerGameState::generateSharedGameState(bool send_
 
 		int num_in_curr_update = 0;
 		for (EntityID id : this->updated_entities) {
-			curr_update.objects.insert({id, all_objects.at(id)});
+			SharedObject shared_obj = this->objects.getObject(id)->toShared();
+
+			curr_update.objects.insert({id, shared_obj});
 			num_in_curr_update++;
 
 			if (num_in_curr_update >= OBJECTS_PER_UPDATE) {

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -402,8 +402,10 @@ std::chrono::milliseconds Server::doTick() {
     }
 
 
+
     // Calculate how long we need to wait until the next tick
     auto stop = std::chrono::high_resolution_clock::now();
+    std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count() << "\n";
     auto wait = std::chrono::duration_cast<std::chrono::milliseconds>(
         TIMESTEP_LEN - (stop - start));
     return wait;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -402,10 +402,8 @@ std::chrono::milliseconds Server::doTick() {
     }
 
 
-
     // Calculate how long we need to wait until the next tick
     auto stop = std::chrono::high_resolution_clock::now();
-    std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count() << "\n";
     auto wait = std::chrono::duration_cast<std::chrono::milliseconds>(
         TIMESTEP_LEN - (stop - start));
     return wait;
@@ -415,6 +413,7 @@ void Server::_doAccept() {
     this->acceptor.async_accept(this->socket,
         [this](boost::system::error_code ec) {
             if (!ec) {
+                this->socket.set_option(boost::asio::ip::tcp::no_delay(true));
                 auto addr = this->socket.remote_endpoint().address();
                 auto new_session = this->_handleNewSession(addr);
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -413,6 +413,7 @@ void Server::_doAccept() {
     this->acceptor.async_accept(this->socket,
         [this](boost::system::error_code ec) {
             if (!ec) {
+                this->socket.set_option(boost::asio::ip::tcp::no_delay(true));
                 auto addr = this->socket.remote_endpoint().address();
                 auto new_session = this->_handleNewSession(addr);
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -413,7 +413,6 @@ void Server::_doAccept() {
     this->acceptor.async_accept(this->socket,
         [this](boost::system::error_code ec) {
             if (!ec) {
-                this->socket.set_option(boost::asio::ip::tcp::no_delay(true));
                 auto addr = this->socket.remote_endpoint().address();
                 auto new_session = this->_handleNewSession(addr);
 

--- a/src/shared/network/session.cpp
+++ b/src/shared/network/session.cpp
@@ -15,7 +15,6 @@ Session::Session(tcp::socket socket, SessionInfo info):
     socket(std::move(socket)),
     info(info)
 {
-    this->socket.set_option(boost::asio::ip::tcp::no_delay(true));
     this->okay = true;
 }
 

--- a/src/shared/network/session.cpp
+++ b/src/shared/network/session.cpp
@@ -15,6 +15,7 @@ Session::Session(tcp::socket socket, SessionInfo info):
     socket(std::move(socket)),
     info(info)
 {
+    this->socket.set_option(boost::asio::ip::tcp::no_delay(true));
     this->okay = true;
 }
 


### PR DESCRIPTION
This branch kind of fixes the tick rate

it fixes an O(n) iteration in the shared game state generation where it was still calling toShared on every single object regardless if it was sent down in the delta update

It also tries to enable a no delay networking mode for the server (wouldnt work on the client)

it also increases the number of objects per packet back to 250 which seems to work in an attempt to fix netwroking related slowdowns

rn we are still experiencing weird tick rate related issues on the demo machines where every so often a tick is missed because sending the packets on the network takes absurdly long

dont know how to solve that, will have to ask tomorrow for help from prof and TA