### PR TITLE
Scale animation speed off frame rate + fix player y positioning

### DIFF
--- a/include/client/client.hpp
+++ b/include/client/client.hpp
@@ -312,6 +312,8 @@ private:
     float mouse_xpos = 0.0f;
     float mouse_ypos = 0.0f;
 
+    double lastTime = 0.0;
+
     GameConfig config;
     tcp::resolver resolver;
     tcp::socket socket;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -630,9 +630,8 @@ void Client::geometryPass() {
                 if (this->session->getInfo().client_eid.has_value() && sharedObject->globalID == this->session->getInfo().client_eid.value()) {
                     //  TODO: Update the player eye level to an acceptable level
 
-                    glm::vec3 pos = sharedObject->physics.getCenterPosition();
+                    glm::vec3 pos = sharedObject->physics.getCenterPosition() - (sharedObject->physics.dimensions.y / 2.0f);
                     pos.y += PLAYER_EYE_LEVEL;
-                    pos.z += 3.0f;
                     cam->updatePos(pos);
 
                     // update listener position & facing
@@ -648,7 +647,7 @@ void Client::geometryPass() {
                     if (!sharedObject->playerInfo->is_alive) {
                         this->gui_state = GUIState::DEAD_SCREEN;
                     }
-                    // break;
+                    break;
                 }
                 animManager->setAnimation(sharedObject->globalID, sharedObject->type, sharedObject->animState);
 
@@ -662,7 +661,7 @@ void Client::geometryPass() {
 
                 if (!sharedObject->playerInfo->render) { break; } // dont render while invisible
 
-                auto player_pos = sharedObject->physics.getCenterPosition();
+                auto player_pos = sharedObject->physics.getCenterPosition() - (sharedObject->physics.dimensions.y / 2.0f);
                 auto player_dir = sharedObject->physics.facing;
 
                 if (player_dir == glm::vec3(0.0f)) {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -600,6 +600,10 @@ void Client::geometryPass() {
     bool is_dm = this->session->getInfo().is_dungeon_master.value();
     glm::vec3 my_pos = this->gameState.objects[eid]->physics.corner;
 
+    double currentTime = glfwGetTime();
+    double timeElapsed = currentTime - lastTime;
+    lastTime = currentTime;
+
     // draw all objects to g-buffer
     for (auto& [id, sharedObject] : this->gameState.objects) {
         if (!sharedObject.has_value()) {
@@ -628,6 +632,7 @@ void Client::geometryPass() {
 
                     glm::vec3 pos = sharedObject->physics.getCenterPosition();
                     pos.y += PLAYER_EYE_LEVEL;
+                    pos.z += 3.0f;
                     cam->updatePos(pos);
 
                     // update listener position & facing
@@ -643,12 +648,12 @@ void Client::geometryPass() {
                     if (!sharedObject->playerInfo->is_alive) {
                         this->gui_state = GUIState::DEAD_SCREEN;
                     }
-                    break;
+                    // break;
                 }
                 animManager->setAnimation(sharedObject->globalID, sharedObject->type, sharedObject->animState);
 
                 /* Update model animation */
-                animManager->updateAnimation(0.025f);
+                animManager->updateAnimation(timeElapsed);
                 auto transforms = animManager->getFinalBoneMatrices();
 
                 for (int i = 0; i < (transforms.size() < 100 ? transforms.size() : 100); ++i) {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -630,7 +630,8 @@ void Client::geometryPass() {
                 if (this->session->getInfo().client_eid.has_value() && sharedObject->globalID == this->session->getInfo().client_eid.value()) {
                     //  TODO: Update the player eye level to an acceptable level
 
-                    glm::vec3 pos = sharedObject->physics.getCenterPosition() - (sharedObject->physics.dimensions.y / 2.0f);
+                    glm::vec3 pos = sharedObject->physics.getCenterPosition();
+                    pos.y -= (sharedObject->physics.dimensions.y / 2.0f);
                     pos.y += PLAYER_EYE_LEVEL;
                     cam->updatePos(pos);
 
@@ -661,7 +662,9 @@ void Client::geometryPass() {
 
                 if (!sharedObject->playerInfo->render) { break; } // dont render while invisible
 
-                auto player_pos = sharedObject->physics.getCenterPosition() - (sharedObject->physics.dimensions.y / 2.0f);
+                auto player_pos = sharedObject->physics.getCenterPosition();
+                player_pos.y -= (sharedObject->physics.dimensions.y / 2.0f);
+
                 auto player_dir = sharedObject->physics.facing;
 
                 if (player_dir == glm::vec3(0.0f)) {


### PR DESCRIPTION
Changes the animation update speed to match the frame rate. More accurately, it updates the animation based on the time between calls to `geometryPass` inside `Client`. 

Also includes a fix to player model and camera height by subtracting by half of the model height, which puts player models on the ground and moves the camera to the correct eye position.