### PR TITLE
Feat/gradient torches

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,7 +14,7 @@
         "lobby_name": "Hope you're doing well!1",
         "lobby_broadcast": true,
         "max_players": 1,
-        "disable_dm": true,
+        "disable_dm": false,
         "skip_intro": true
     },
     "client": {

--- a/include/server/game/servergamestate.hpp
+++ b/include/server/game/servergamestate.hpp
@@ -371,11 +371,15 @@ private:
      * cell
      * @param cell is a single cell of the maze's grid where a wall + torch
      * should be placed
+	 * @param orb_pos position of the orb so that we can calculate the distance
+	 * for coloring purposes
+	 * @param exit_pos position of the exit so that we can calculate the distance
+	 * for coloring purposes
      * @param cellType determines which direction the torch should face. 
      * This means that only TorchUp, TorchDown, TorchRight, and TorchLeft
      * are acceptable values of cellType 
      */
-    void spawnTorch(GridCell *cell);
+    void spawnTorch(GridCell *cell, glm::vec3 orb_pos, glm::vec3 exit_pos);
 
     /**
      * @brief helper function to spawn a fireball trap 

--- a/include/server/game/torchlight.hpp
+++ b/include/server/game/torchlight.hpp
@@ -35,8 +35,10 @@ public:
 	/**
      * Creates a torchight with default lighting properties.
 	 * @param corner Corner position of the surface
+     * @param dist_orb distance to orb, to see if it should be shaded blue
+     * @param dist_exit distance to the exit, to see if it should be shaded white
 	 */
-	explicit Torchlight(glm::vec3 corner);
+	explicit Torchlight(glm::vec3 corner, float dist_orb, float dist_exit);
 
 	/**
 	 * @param corner Corner position of the surface

--- a/src/server/game/servergamestate.cpp
+++ b/src/server/game/servergamestate.cpp
@@ -1865,6 +1865,29 @@ void ServerGameState::loadMaze(const Grid& grid) {
 		}
 	}
 
+	std::optional<glm::vec3> orb_pos;
+	std::optional<glm::vec3> exit_pos;
+	// go through and mark distance to orb and exit
+	for (int c = 0; c < this->grid.getColumns(); c++) {
+		for (int r = 0; r < this->grid.getRows(); r++) {
+			CellType type = this->grid.getCell(c, r)->type;
+			if (type == CellType::Orb || type == CellType::Exit) {
+				glm::vec3 corner(c * Grid::grid_cell_width, 0.0f, r * Grid::grid_cell_width);
+
+				if (type == CellType::Orb) {
+					orb_pos = corner;
+				} else {
+					exit_pos = corner;
+				}
+
+			}
+		}
+
+		if (orb_pos.has_value() && exit_pos.has_value()) {
+			break; // early exit, not really needed though probably
+		}
+	}
+
     // create multiple floor and ceiling objects to populate the size of the entire maze. 
     // currently doing this to stretch out the floor texture by the desired factor. here
     // in the maze generation we can have a lot of control over how frequently the floor texture
@@ -2097,7 +2120,10 @@ void ServerGameState::loadMaze(const Grid& grid) {
                 case CellType::TorchDown:
                 case CellType::TorchRight:
                 case CellType::TorchLeft: {
-                    this->spawnTorch(cell);
+					// if no orb or exit in maze then just tell it that they are very far off so not
+					// considered in color calculations
+					const glm::vec3 FAR_OFF_POS(10000, 10000, 10000);
+					this->spawnTorch(cell, orb_pos.value_or(FAR_OFF_POS), exit_pos.value_or(FAR_OFF_POS));
                     this->spawnWall(cell, col, row, internal_walls.contains(glm::ivec2(col, row)));
                     break;
                 }
@@ -2227,13 +2253,16 @@ void ServerGameState::spawnWall(GridCell* cell, int col, int row, bool is_intern
     }
 }
 
-void ServerGameState::spawnTorch(GridCell *cell) {
+void ServerGameState::spawnTorch(GridCell *cell, glm::vec3 orb_pos, glm::vec3 exit_pos) {
     glm::vec3 dimensions = Object::models.at(ModelType::Torchlight);
     glm::vec3 corner(
         cell->x * this->grid.grid_cell_width,
         MAZE_CEILING_HEIGHT / 2.0f,
         cell->y * this->grid.grid_cell_width
     );
+
+	float orb_dist = glm::distance(corner, orb_pos);
+	float exit_dist = glm::distance(corner, exit_pos);
 
     switch (cell->type) {
         case CellType::TorchDown: {
@@ -2271,7 +2300,7 @@ void ServerGameState::spawnTorch(GridCell *cell) {
 		true
 	));
 
-    this->objects.createObject(new Torchlight(corner));
+    this->objects.createObject(new Torchlight(corner, orb_dist, exit_dist));
 }
 
 Trap* ServerGameState::spawnFireballTrap(GridCell *cell) {

--- a/src/server/game/torchlight.cpp
+++ b/src/server/game/torchlight.cpp
@@ -5,6 +5,7 @@
 #include "server/game/object.hpp"
 #include "shared/game/sharedobject.hpp"
 #include "shared/utilities/rng.hpp"
+#include "server/game/grid.hpp"
 
 SharedObject Torchlight::toShared() {
     auto so = Object::toShared();
@@ -20,34 +21,74 @@ SharedObject Torchlight::toShared() {
 }
 
 Torchlight::Torchlight(
-    glm::vec3 corner):
+    glm::vec3 corner, float dist_orb, float dist_exit):
 	Object(ObjectType::Torchlight, Physics(false, 
 		Collider::Box, corner, glm::vec3(0.0f), glm::vec3(1.0f)),
 		ModelType::Torchlight)
 {
-    // for amber orange lights
-    this->properties = TorchlightProperties {
-        .flickering = true,
-        .min_intensity = 0.3f,
-        .max_intensity = 1.0f,
-        .ambient_color = glm::vec3(0.05f, 0.05f, 0.05f),
-        .diffuse_color = glm::vec3(1.0f, 0.5f, 0.03f),
-        .specular_color = glm::vec3(0.5f, 0.25f, 0.015f),
-        .attenuation_linear = 0.07f,
-        .attenuation_quadratic = 0.017f
-    };
+    const float MIN_ORB_DIST = Grid::grid_cell_width * 30.0f; // min distance to start shade blue
+    const float MIN_EXIT_DIST = Grid::grid_cell_width * 30.0f; // min distance to start shade white
+
+    const float AMBER_MIN_INTENSITY = 0.3f;
+    const float AMBER_MAX_INTENSITY = 1.0f;
+    const glm::vec3 AMBER_AMBIENT(0.05f, 0.05f, 0.05f);
+    const glm::vec3 AMBER_DIFFUSE(1.0f, 0.5f, 0.03f);
+    const glm::vec3 AMBER_SPECULAR(0.5f, 0.25f, 0.015f);
+
+    const float BLUE_MIN_INTENSITY = 0.1f;
+    const float BLUE_MAX_INTENSITY = 0.5f;
+    const glm::vec3 BLUE_AMBIENT(0.0f, 0.75f, 0.67f);
+    const glm::vec3 BLUE_DIFFUSE(0.0f, 0.75f, 0.67f);
+    const glm::vec3 BLUE_SPECULAR(0.0f, 0.35, 0.33f);
+
+    const float WHITE_MIN_INTENSITY = 0.1f;
+    const float WHITE_MAX_INTENSITY = 0.3f;
+    const glm::vec3 WHITE_AMBIENT(1.05f, 1.05f, 1.05f);
+    const glm::vec3 WHITE_DIFFUSE(1.0f, 1.0f, 1.0f);
+    const glm::vec3 WHITE_SPECULAR(0.5f, 0.5f, 0.5f);
+
+    const float ATTEN_LINEAR = 0.07f;
+    const float ATTEN_QUAD = 0.017f;
+
+    if (dist_orb < MIN_ORB_DIST) {
+        // close to orb, so shade blue
+        this->properties = TorchlightProperties {
+            .flickering = true,
+            .min_intensity = BLUE_MIN_INTENSITY,
+            .max_intensity = BLUE_MAX_INTENSITY,
+            .ambient_color = BLUE_AMBIENT,
+            .diffuse_color = BLUE_DIFFUSE,
+            .specular_color = BLUE_SPECULAR,
+            .attenuation_linear = ATTEN_LINEAR,
+            .attenuation_quadratic = ATTEN_QUAD
+        };
+    } else if (dist_exit < MIN_EXIT_DIST) {
+        // close to exit, so shade white
+        // TEMP: still amber
+        this->properties = TorchlightProperties {
+            .flickering = true,
+            .min_intensity = WHITE_MIN_INTENSITY,
+            .max_intensity = WHITE_MAX_INTENSITY,
+            .ambient_color = WHITE_AMBIENT,
+            .diffuse_color = WHITE_DIFFUSE,
+            .specular_color = WHITE_SPECULAR,
+            .attenuation_linear = ATTEN_LINEAR,
+            .attenuation_quadratic = ATTEN_QUAD
+        };
+    } else {
+        // shade normal amber
+        this->properties = TorchlightProperties {
+            .flickering = true,
+            .min_intensity = AMBER_MIN_INTENSITY,
+            .max_intensity = AMBER_MAX_INTENSITY,
+            .ambient_color = AMBER_AMBIENT,
+            .diffuse_color = AMBER_DIFFUSE,
+            .specular_color = AMBER_SPECULAR,
+            .attenuation_linear = ATTEN_LINEAR,
+            .attenuation_quadratic = ATTEN_QUAD
+        };
+    }
     
-    // for blue lights
-    // this->properties = TorchlightProperties {
-    //     .flickering = true,
-    //     .min_intensity = 0.1f,
-    //     .max_intensity = 0.5f,
-    //     .ambient_color = glm::vec3(0.0f, 0.75f, 0.67f),
-    //     .diffuse_color = glm::vec3(0.0f, 0.75f, 0.67f),
-    //     .specular_color = glm::vec3(0.0f, 0.35f, 0.33f),
-    //     .attenuation_linear = 0.07f,
-    //     .attenuation_quadratic = 0.017f
-    // };
     init();
 }
 

--- a/src/server/game/torchlight.cpp
+++ b/src/server/game/torchlight.cpp
@@ -26,8 +26,8 @@ Torchlight::Torchlight(
 		Collider::Box, corner, glm::vec3(0.0f), glm::vec3(1.0f)),
 		ModelType::Torchlight)
 {
-    const float MIN_ORB_DIST = Grid::grid_cell_width * 30.0f; // min distance to start shade blue
-    const float MIN_EXIT_DIST = Grid::grid_cell_width * 30.0f; // min distance to start shade white
+    const float MIN_ORB_DIST = Grid::grid_cell_width * 60.0f;
+    const float MIN_EXIT_DIST = Grid::grid_cell_width * 60.0f; // min distance to start shade white
 
     const float AMBER_MIN_INTENSITY = 0.3f;
     const float AMBER_MAX_INTENSITY = 1.0f;
@@ -50,28 +50,37 @@ Torchlight::Torchlight(
     const float ATTEN_LINEAR = 0.07f;
     const float ATTEN_QUAD = 0.017f;
 
+    // higher intensity takes you closer to color2
+    const auto interpolateColor = [](float intensity, glm::vec3 color1, glm::vec3 color2) {
+        return color1 + intensity * (color2 - color1);
+    };
+
     if (dist_orb < MIN_ORB_DIST) {
+        // the closer you get, the higher the factor to make it more white is multiplied
+        const float blue_intensity = (MIN_ORB_DIST - dist_orb) / MIN_ORB_DIST;
+
         // close to orb, so shade blue
         this->properties = TorchlightProperties {
             .flickering = true,
             .min_intensity = BLUE_MIN_INTENSITY,
             .max_intensity = BLUE_MAX_INTENSITY,
-            .ambient_color = BLUE_AMBIENT,
-            .diffuse_color = BLUE_DIFFUSE,
-            .specular_color = BLUE_SPECULAR,
+            .ambient_color = interpolateColor(blue_intensity, AMBER_AMBIENT, BLUE_DIFFUSE),
+            .diffuse_color = interpolateColor(blue_intensity, AMBER_DIFFUSE, BLUE_DIFFUSE),
+            .specular_color = interpolateColor(blue_intensity, AMBER_SPECULAR, BLUE_SPECULAR),
             .attenuation_linear = ATTEN_LINEAR,
             .attenuation_quadratic = ATTEN_QUAD
         };
     } else if (dist_exit < MIN_EXIT_DIST) {
+        const float white_intensity = (MIN_EXIT_DIST - dist_exit) / MIN_EXIT_DIST;
         // close to exit, so shade white
         // TEMP: still amber
         this->properties = TorchlightProperties {
             .flickering = true,
             .min_intensity = WHITE_MIN_INTENSITY,
             .max_intensity = WHITE_MAX_INTENSITY,
-            .ambient_color = WHITE_AMBIENT,
-            .diffuse_color = WHITE_DIFFUSE,
-            .specular_color = WHITE_SPECULAR,
+            .ambient_color = interpolateColor(white_intensity, AMBER_AMBIENT, WHITE_AMBIENT),
+            .diffuse_color = interpolateColor(white_intensity, AMBER_DIFFUSE, WHITE_DIFFUSE),
+            .specular_color = interpolateColor(white_intensity, AMBER_SPECULAR, WHITE_SPECULAR),
             .attenuation_linear = ATTEN_LINEAR,
             .attenuation_quadratic = ATTEN_QUAD
         };


### PR DESCRIPTION
This PR makes torches have a gradient color as you get closer to the orb and exit.
Getting closer to the orb makes the torches more blue, and getting closer to the exit makes the torches more white.

currently, the distance cutoff for starting the gradient for both orb and exit is 60 grid cells. The screenshots I sent in discord were at 50 grid cells, but I slightly tuned it up a bit so there would be more space across which the gradient is seen.